### PR TITLE
feat(website): add donation page wireframe

### DIFF
--- a/website/app.py
+++ b/website/app.py
@@ -31,6 +31,7 @@ SAMPLE_CAMPAIGNS = [
         "goal": 2500,
         "managers": ["Chris the camel", "Carissa the camel"],
         "updated": datetime.date(2021, 2, 1),
+        "donations": ["cccc-oooo-oooo-llll"],
     },
     {
         "id": "eeee-ffff-gggg-hhhh",
@@ -40,13 +41,49 @@ SAMPLE_CAMPAIGNS = [
             "Fred the fish",
         ],
         "updated": datetime.date(2021, 5, 10),
+        "donations": [],
     },
+]
+
+SAMPLE_DONATIONS = [
+    {
+        "id": "cccc-oooo-oooo-llll",
+        "campaign": "aaaa-bbbb-cccc-dddd",
+        "donor": "aaaa-dddd-aaaa-mmmm",
+        "amount": 100,
+        "timeCreated": datetime.date(2021, 5, 20),
+    }
 ]
 
 
 @app.route("/")
 def webapp_list_campaigns():
     return render_template("home.html", campaigns=SAMPLE_CAMPAIGNS)
+
+
+@app.route("/donate", methods=["GET"])
+def webapp_donate_get():
+    campaign_id = request.args["campaign_id"]
+    campaign_instance = [
+        campaign for campaign in SAMPLE_CAMPAIGNS if campaign["id"] == campaign_id
+    ][0]
+    return render_template("donate-to-campaign.html", campaign=campaign_instance)
+
+
+@app.route("/donate", methods=["POST"])
+def webapp_donate_post():
+    # TODO: do something with the collected data
+    campaign_id = request.form["campaignId"]
+    campaign_instance = [
+        campaign for campaign in SAMPLE_CAMPAIGNS if campaign["id"] == campaign_id
+    ][0]
+
+    donation_id = campaign_instance["donations"][0]
+
+    print("Amount: ", request.form["amount"])
+    print("Anonymous?: ", request.form.get("anonymous", False))
+
+    return redirect("/viewDonation?donation_id=" + donation_id)
 
 
 @app.route("/createCampaign", methods=["GET"])
@@ -71,5 +108,23 @@ def webapp_view_campaign():
         campaign for campaign in SAMPLE_CAMPAIGNS if campaign["id"] == campaign_id
     ][0]
     return render_template("view-campaign.html", campaign=campaign_instance)
+
+
+@app.route("/viewDonation", methods=["GET"])
+def webapp_view_donation():
+    donation_id = "cccc-oooo-oooo-llll"  # TODO: fetch value from API
+    donation_instance = [
+        donation for donation in SAMPLE_DONATIONS if donation["id"] == donation_id
+    ][0]
+
+    campaign_id = donation_instance["campaign"]
+    campaign_instance = [
+        campaign for campaign in SAMPLE_CAMPAIGNS if campaign["id"] == campaign_id
+    ][0]
+
+    return render_template(
+        "view-donation.html", donation=donation_instance, campaign=campaign_instance
+    )
+
 
 app.run()

--- a/website/templates/donate-to-campaign.html
+++ b/website/templates/donate-to-campaign.html
@@ -1,0 +1,39 @@
+<!--
+  Copyright 2021 Google LLC
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<!doctype html>
+<title>Donate | Cymbal Giving</title>
+
+<a href="/viewCampaign?campaignId={{ campaign.id }}">
+  Back to campaign
+</a>
+
+<form method="POST">
+    <p>
+        Donate to the <b>{{ campaign.name}}</b> campaign:
+    </p>
+    <p>
+        <label for="amount">Amount (in USD):</label>
+        <input type="text" id="amount" name="amount">
+    </p>
+    <p>
+        <label for="anonymous">Keep me anonymous</label>
+        <input type="checkbox" id="anonymous" name="anonymous" value="false">
+    </p>
+
+    <input type="hidden" value="{{ campaign.id }}" id="campaignId" name="campaignId" />
+    <input type="submit" value="Submit">
+</form>
+

--- a/website/templates/view-donation.html
+++ b/website/templates/view-donation.html
@@ -1,0 +1,43 @@
+<!--
+  Copyright 2021 Google LLC
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<!doctype html>
+<title>View Donation | Cymbal Giving</title>
+
+<a href="/">Back to campaign list</a>
+
+<p>
+    <b>Donation ID:</b>
+    {{ donation.id }}
+</p>
+
+<p>
+    <b>Campaign Name:</b>
+    {{ campaign.name }}
+</p>
+
+<p>
+    <b>Amount:</b>
+    {{ donation.amount }}
+</p>
+
+<p>
+    <b>Time:</b>
+    {{ donation.timeCreated }}
+</p>
+
+<p>
+  <a href="/donate?campaign_id={{ campaign.id }}">Donate again</a>
+</p>


### PR DESCRIPTION
This adds the "View Donation" and "Donate to Campaign" UI wireframes.

Reviewers:
- @engelke (API lead) 
- @grayside (project lead)

@dinagraves happy to add you to reviewers too, if you'd like.