### PR TITLE
feat(website): Draft initial CSS style

### DIFF
--- a/website/app.py
+++ b/website/app.py
@@ -28,17 +28,21 @@ SAMPLE_CAMPAIGNS = [
     {
         "id": "aaaa-bbbb-cccc-dddd",
         "name": "cash for camels",
+        "image_url": "https://images.pexels.com/photos/2080195/pexels-photo-2080195.jpeg?auto=compress&cs=tinysrgb&dpr=2&h=750&w=1260",
         "goal": 2500,
         "managers": ["Chris the camel", "Carissa the camel"],
+        "description": "The camels need money.",
         "updated": datetime.date(2021, 2, 1),
     },
     {
         "id": "eeee-ffff-gggg-hhhh",
         "name": "water for fish",
+        "image_url": "https://images.pexels.com/photos/2156311/pexels-photo-2156311.jpeg?auto=compress&cs=tinysrgb&dpr=2&h=750&w=1260",
         "goal": 2500,
         "managers": [
             "Fred the fish",
         ],
+        "description": "Help us keep all the fish hydrated!",
         "updated": datetime.date(2021, 5, 10),
     },
 ]

--- a/website/static/site.css
+++ b/website/static/site.css
@@ -1,0 +1,129 @@
+/**
+  Copyright 2021 Google LLC
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+**/
+
+body {
+  margin: 0;
+  color: #505050;
+  font-family: Roboto, sans-serif;
+}
+
+a {
+  color: #505050;
+  text-decoration: none;
+}
+
+.emblem-message {
+  width: 100%;
+  background-color: #efefef;
+  color: #606060;
+  display: block;
+  padding: 0.75em;
+  font-size: 14px;
+}
+
+.material-icons {
+
+}
+
+.emblem-message .material-icons {
+  position: relative;
+  top: 2px;
+  font-size: 14px;
+}
+
+.emblem-hero-image {
+  width: fit-content;
+  height: 33vh;
+}
+
+.emblem-hero-image img {
+  width: 100%;
+  height: 100%;
+}
+
+.emblem-unpadded-grid.mdc-layout-grid {
+  padding: 0px;
+}
+
+.emblem-unpadded-grid {
+  padding: 24px;
+}
+
+.emblem-align-right {
+  text-align: right;
+}
+
+/**** Campaign cards ****/
+.mdc-card {
+  padding: 16px;
+}
+
+.mdc-list-divider,
+.mdc-card.emblem-campaign-card .mdc-list-item a {
+  padding: 8px 0;
+}
+
+.emblem-campaign-card {
+  font-size: 18px;
+}
+
+/* Title */
+.emblem-campaign-card .emblem-campaign-title {
+  font-size: 30px;
+  position: relative;
+  top: -0.3em;
+}
+
+.emblem-campaign-card .emblem-campaign-title .material-icons {
+  position: relative;
+  top: 0.1em;
+}
+
+/* Campaign image */
+.emblem-campaign-card .emblem-campaign-image {
+  padding: 0;
+  margin: -16px;
+}
+
+.emblem-campaign-card .emblem-campaign-image img {
+  width: fit-content;
+  height: 20em;
+  padding-bottom: 8px;
+}
+
+/* Donate button */
+.emblem-campaign-card .emblem-campaign-donate a {
+  color: #6300ee;
+}
+
+.emblem-campaign-card .emblem-campaign-donate .material-icons {
+  font-size: 16px;
+  position: relative;
+  top: 0.15em;
+}
+
+/* Learn more button */
+.emblem-campaign-card .emblem-campaign-learn-more {
+  position: relative;
+  left: -0.5em;
+}
+
+.emblem-campaign-card .emblem-campaign-learn-more .material-icons {
+  position: relative;
+  top: 0.25em;
+  left: 0.1em;
+}  
+/**** End campaign cards ****/

--- a/website/templates/base.html
+++ b/website/templates/base.html
@@ -1,0 +1,62 @@
+<!--
+  Copyright 2021 Google LLC
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<!doctype html>
+
+<head>
+  <!-- Include Material Design components -->
+  <link href="https://unpkg.com/material-components-web@latest/dist/material-components-web.min.css" rel="stylesheet">
+  <script src="https://unpkg.com/material-components-web@latest/dist/material-components-web.min.js"></script>
+  <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons">
+
+  <!--
+    Site-wide CSS
+    TODO(anassri): move this to a CDN of some sort (GCS?)
+  -->
+  <link href="/static/site.css" rel="stylesheet">
+
+  <!-- Page title -->
+  <title>{% block title %}{% endblock %} | Cymbal Giving</title>
+</head>
+
+<body>
+  <!-- App bar -->
+  <header class="mdc-top-app-bar mdc-top-app-bar--fixed">
+    <div class="mdc-top-app-bar__row">
+      <section class="mdc-top-app-bar__section mdc-top-app-bar__section--align-start">
+        <button class="material-icons mdc-top-app-bar__navigation-icon mdc-icon-button" aria-label="Open navigation menu">menu</button>
+        <span class="mdc-top-app-bar__title">{{ self.title() }}</span>
+      </section>
+      <section class="mdc-top-app-bar__section mdc-top-app-bar__section--align-end" role="toolbar">
+        <button class="material-icons mdc-top-app-bar__action-item mdc-icon-button" aria-label="Help">help_outline</button>
+        <button class="material-icons mdc-top-app-bar__action-item mdc-icon-button" aria-label="Search Campaigns">search</button>
+        <button class="material-icons mdc-top-app-bar__action-item mdc-icon-button" aria-label="Profile">account_circle</button>
+      </section>
+    </div>
+  </header>
+
+  <main class="mdc-top-app-bar--fixed-adjust">
+
+    <!-- Messages -->
+    <div class="emblem-message">
+      <span class="material-icons">
+        info
+      </span>
+      Emblem Giving is a demo app; no money will be moved in exploring these features.
+    </div>
+
+    {% block content %}{% endblock %}
+  </main>
+</body>

--- a/website/templates/home.html
+++ b/website/templates/home.html
@@ -13,38 +13,94 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
-<!doctype html>
-<title>View Campaigns | Cymbal Giving</title>
 
-<a href="/createCampaign">Create new campaign</a>
+{% extends "base.html" %}
 
-{% for campaign in campaigns %}
-    <div>
-        <p>
-            <b>Campaign name:</b>
-            {{ campaign.name }}
-        </p>
-        <p>
-            <b>Goal:</b>
-            {{ campaign.goal }}
-        </p>
-        <p>
-            <b>Managers:</b>
-            <ul>
-            {% for manager in campaign.managers %}
-                <li>{{ manager }}</li>
-            {% endfor %}
-            </ul>
-        </p>
-        <p>
-            <b>Last updated:</b>
-            {{ campaign.updated }}
-        </p>
-        <p>
-            <a href="/viewCampaign?campaign_id={{ campaign.id }}">
-                Campaign details
-            </a>
-        </p>
+{% block title %}View campaigns{% endblock %}
+
+{% block content %}
+  <!-- Hero image -->
+  <div class="emblem-unpadded-grid mdc-layout-grid">
+    <div class="mdc-layout-grid__inner">
+      <div class="emblem-hero-image mdc-layout-grid__cell mdc-layout-grid__cell--span-12">
+        <img src="https://images.pexels.com/photos/189349/pexels-photo-189349.jpeg?auto=compress&cs=tinysrgb&dpr=2&h=750&w=1260" />
+      </div>
+      </div>
+  </div>
+
+  <!-- Hero subtitle -->
+  <div class="mdc-layout-grid">
+    <div class="mdc-layout-grid__inner">
+
+      <div class="mdc-layout-grid__cell mdc-layout-grid__cell--span-6">
+        Discover a giving campaign for your contribution!
+      </div>
+      <div class="emblem-align-right mdc-layout-grid__cell mdc-layout-grid__cell--span-6">
+        $1,234.00 contributed
+      </div>
     </div>
-    <hr />
-{% endfor %}
+  </div>
+
+  <!-- Campaign list -->
+  <div class="mdc-layout-grid">
+    <div class="mdc-layout-grid__inner">
+      {% for campaign in campaigns %}
+        <div class="mdc-layout-grid__cell mdc-layout-grid__cell--span-6">
+          <div class="emblem-campaign-card mdc-card mdc-card--outlined">
+            <div class="mdc-list-group">
+              <ul class="mdc-list">
+
+                <!-- Campaign name -->
+                <li class="emblem-campaign-title mdc-list-item">
+                  <span class="mdc-list-item__text">
+                    <span class="material-icons">favorite</span>
+                    {{ campaign.name }}
+                  </span>
+                </li>
+                <li role="separator" class="mdc-list-divider"></li>
+
+                <!-- Campaign image -->
+                <li class="emblem-campaign-image mdc-list-item">
+                  <img src="{{ campaign.image_url }}" />
+                </li>
+                <li role="separator" class="mdc-list-divider"></li>
+
+                <!-- Campaign description -->
+                <li class="mdc-list-item">
+                  <span class="mdc-list-item__text">
+                    {{ campaign.description }}
+                  </span>
+                </li>
+                <li role="separator" class="mdc-list-divider"></li>
+
+                <!-- Donate button -->
+                <li class="emblem-campaign-donate mdc-list-item">
+                  <span class="mdc-list-item__ripple"></span>
+                  <a class="mdc-list-item__text" href="/viewCampaign?campaign_id={{ campaign.id }}">
+                      <span class="material-icons">card_giftcard</span>
+                      DONATE
+                  </a>
+                </li>
+                <li role="separator" class="mdc-list-divider"></li>
+
+                <!-- Learn more button -->
+                <li class="emblem-campaign-learn-more mdc-list-item">
+                  <span class="mdc-list-item__ripple"></span>
+                  <span class="mdc-list-item__text">
+                    <span class="material-icons">chevron_right</span>
+                    <a href="/viewCampaign?campaign_id={{ campaign.id }}">
+                        Learn more
+                    </a>
+                  </span>
+                </li>
+
+              </ul>
+            </div>
+          </div>
+        </div>
+      {% endfor %}
+    </div>
+  </div>
+
+  <a href="/createCampaign">Create new campaign</a>
+{% endblock %}


### PR DESCRIPTION
This PR creates a "canonical CSS layout" that other pages can re-use. Once this PR is merged, I'll distribute the frontend work via `help wanted` GitHub issues.

Here's a screenshot of the (home)page itself:

<img width="1277" alt="Screen Shot 2021-06-09 at 6 46 50 PM" src="https://user-images.githubusercontent.com/2309317/121451878-3abf0d80-c953-11eb-9bfa-b94028a9d3e9.png">

--------

Nit: we may want to revise the color scheme - I used purple since that was Material's default, but something like blue or red might better suit us.