### PR TITLE
feat(website): support env var configs

### DIFF
--- a/website/README.md
+++ b/website/README.md
@@ -30,14 +30,18 @@ To do this, you must [configure Google as an Identity Platform](https://cloud.go
 some - _but not all_ - application pages.
 
 ### Configuration
-To configure the app, first rename `config.default.py` to `config.py`.
+To configure the app, set the following environment variables:
 
-Then, specify the following values in `config.py`:
- - Your Firebase API key
- - Your Firebase Auth domain
+---------------------------------------------------------------------------------------------
+| **Variable name**             | **Description**                                           |
+| `EMBLEM_FIREBASE_API_KEY`     | The Firebase API key provided by Cloud Identity Platform. |
+| `EMBLEM_FIREBASE_AUTH_DOMAIN` | The auth domain (usually of the form `*.firebaseapp.com`) |
+| `EMBLEM_API_URL`              | A URL pointing to your instance of the Emblem Content API |
+---------------------------------------------------------------------------------------------
 
-You can determine these values by vising the
-[Identity Providers page](https://console.cloud.google.com/customer-identity/providers) and clicking on the `Application Setup Details` button.
+You can determine the `EMBLEM_FIREBASE_*` values by vising the
+[Identity Providers page](https://console.cloud.google.com/customer-identity/providers) and clicking on the `Application Setup Details` button. The `EMBLEM_API_URL` value will be determined
+by where you host the Content API. (If you're using Cloud Run, it will look something like `https://<SERVICE_NAME>-<HASH>.run.app`)
 
 Congratulations! You are now ready to run the Emblem web app.
 

--- a/website/config.py
+++ b/website/config.py
@@ -27,3 +27,6 @@ FIREBASE_API_KEY = os.getenv("EMBLEM_FIREBASE_API_KEY")
 
 # The domain name used by Firebase Auth
 FIREBASE_AUTH_DOMAIN = os.getenv("EMBLEM_FIREBASE_AUTH_DOMAIN")
+
+# The URL the Emblem Content API is hosted at
+API_URL = os.getenv("EMBLEM_API_URL")

--- a/website/views/campaigns.py
+++ b/website/views/campaigns.py
@@ -14,13 +14,13 @@
 
 from sample_data import SAMPLE_DONATIONS
 
+from config import API_URL
+
 from flask import Blueprint, redirect, request, render_template
 
 import requests
 
 campaigns_bp = Blueprint("campaigns", __name__, template_folder="templates")
-
-API_URL = "https://api-pwrmtjf4hq-uc.a.run.app"
 
 
 @campaigns_bp.route("/")


### PR DESCRIPTION
This migrates the existing (hard-coded) `config.default.py` values to environment variables fetched by `config.py`.

It also adds an `EMBLEM_API_URL` environment variable instead of hard-coding the API URL.

Fixes #170; related to #152.