### PR TITLE
fix(Content API client libs): workaround generated libraries issue

### DIFF
--- a/client-libs/python/emblem_client/__init__.py
+++ b/client-libs/python/emblem_client/__init__.py
@@ -35,7 +35,7 @@ class EmblemClient(object):
             client = DefaultApi(api_client=ApiClient(
                 configuration=conf,
                 header_name="Authorization",
-                header_value=access_token,
+                header_value="Bearer " + access_token,
             ))
         else:
             client = DefaultApi(api_client=ApiClient(


### PR DESCRIPTION
The generated libraries are ignoring conf.access_token, so force the header that they should be creating.