### PR TITLE
feat: Add action workflow for blocking merge via labels

### DIFF
--- a/.github/workflows/block-merge.yml
+++ b/.github/workflows/block-merge.yml
@@ -1,0 +1,40 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the 'License');
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an 'AS IS' BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Adapted from https://github.com/cclauss/autoblack
+
+name: Block Merge
+on:
+  pull_request:
+    types: [labeled, unlabeled]
+
+jobs:
+  check-label:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check Labels
+        uses: actions/github-script@v4
+        with:
+          script: |
+            const labels = context.payload.pull_request.labels;
+            const labels_included = labels.filter((label) => {
+              return label.name.includes('do not merge') || label.name.includes('needs');
+            })
+            if (labels_included.length > 0) {
+              const names = labels_included.map(label => label.name);
+              const errors = names.join(', ');
+              core.setFailed(`PR has labels: ${errors} - blocking merge`);
+            } else {
+              core.info('No blocking labels');
+            }


### PR DESCRIPTION
Addresses #138 

On each label/un-label event on a pull request will execute the workflow. The settings need to be updated to have this required status check.

Limitations of GitHub Actions:
* Each label add or removal, even if done as a batch, triggers a check in the checks tab though it should only show up once in the PR status checks.  

Decisions made:
* This uses action `actions/github-script@v4` to extract the event and PR context for more control and results in only 1 status check. This is compared to Adam's example using workflow expressions and functions to extract this information. There was minimal control over arrays of labels.

Future considerations:
* This similar pattern using `actions/github-script@v4`  can be used to add labels on PR creation
```
     - uses: actions/github-script@v3
        with:
          github-token: ${{secrets.GITHUB_TOKEN}}
          script: |
            github.issues.addLabels({
              issue_number: context.issue.number,
              owner: context.repo.owner,
              repo: context.repo.repo,
              labels: ['do not merge']
            })
```

* Similar add comments to the PR
```
github.issues.createComment({
  issue_number: context.issue.number,
  owner: context.repo.owner,
  repo: context.repo.repo,
  body: welcomeMessage
});
```

* Lastly, can read the PR body
```
      - uses: actions/github-script@v4
        with:
          script: |
            const body = context.payload.pull_request.body;
            if (body.includes("Decision Record")) {
         ...
```