### PR TITLE
fix(website): Fix API URL variable mismatch

### DIFF
--- a/website/middleware/auth.py
+++ b/website/middleware/auth.py
@@ -25,5 +25,5 @@ def init(app):
         id_token = request.cookies.get("session", None)
 
         g.api = emblem_client.EmblemClient(
-            app.config.get("API_URL", None), access_token=id_token
+            app.config.get("EMBLEM_API_URL", None), access_token=id_token
         )


### PR DESCRIPTION
The Cloud Build triggers use EMBLEM_API_URL, without this it's falling back to a test server.