### PR TITLE
fix(demo services): incorrect API quickstart "Open in Cloud Shell" link #215

### DIFF
--- a/docs/tutorials/api-quickstart.md
+++ b/docs/tutorials/api-quickstart.md
@@ -4,7 +4,7 @@ This tutorial shows you how to quickly deploy the Emblem Giving API to Cloud Run
 
 The Cloud Run Emulator comes built in to Cloud Shell. It allows you to configure an environment that is representative of your service running on Cloud Run, without incurring charges on your GCP billing account.
 
-For the best experience, launch this tutorial as an interactive walkthrough on Cloud Shell: [Open in Cloud Shell](https://ssh.cloud.google.com/cloudshell/editor?cloudshell_git_repo=https://github.com/GoogleCloudPlatform/emblem&cloudshell_git_branch=main&cloudshell_tutorial=docs/tutorials/api.md). 
+For the best experience, launch this tutorial as an interactive walkthrough on Cloud Shell: [Open in Cloud Shell](https://ssh.cloud.google.com/cloudshell/editor?cloudshell_git_repo=https://github.com/GoogleCloudPlatform/emblem&cloudshell_git_branch=main&cloudshell_tutorial=docs/tutorials/api-quickstart.md).
 
 Let's get started!
 


### PR DESCRIPTION
Minor fix to launch the tutorial in Cloud Shell