### PR TITLE
chore(website): remove config.py from gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,3 @@
-# Website secret files
-website/config.py
-
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]


### PR DESCRIPTION
`config.py` no longer contains secret values directly (they're in env vars instead), so we can remove it from `.gitignore`

_Part of #225_