### PR TITLE
docs: migrate rollback and service account to standalone format

### DIFF
--- a/docs/decisions/2021-05-rollback.md
+++ b/docs/decisions/2021-05-rollback.md
@@ -1,0 +1,44 @@
+# Rollback for Cloud Run uses Traffic Splitting
+
+* **Status:** approved
+* **Last Updated:** 2021-05
+* **Builds on:** [Use Cloud Build for Cloud Resource management](2021-05-pipelines.md)
+* **Objective:** Define "rollback" and how we implement it
+
+## Context & Problem Statement
+
+If we detect a problem in a deployment, we need a way to undo the deployment. The language in this space is inconsistent, so we want to use "rollback" as our baseline, but define what that means and how we'll execute it.
+
+In the event of a bad deployment, we want to be able to revert to previous service configuration & codebase.
+
+## Priorities & Constraints <!-- optional -->
+
+* Get back to a running system quickly
+* Minimize risk of introducing new bugs
+* Managing rollbacks on data schemas or underlying infrastructure is important but lower priority.
+
+## Considered Options
+
+* Option 1: Redeploy a known-good container with previously used configuration
+* Option 2: Route traffic to previous known-good revision
+
+## Decision
+
+Chosen option [Option 2]: Re-route Traffic
+
+[Rollbacks, gradual rollouts, and traffic migration](https://cloud.google.com/run/docs/rollouts-rollbacks-traffic-migration) defines straightforward commands that can be used to redirect traffic for a service to a revision or known, mutable "tag".
+
+This will allow a relatively easy decision to send traffic to a known working revision without the overhead or risk of rebuilding a release artifact or retrieving and reapplying configuration.
+
+This is easy for the whole team to reason about.
+
+### Expected Consequences <!-- optional -->
+
+* Not all hosting platforms have this capability, which means if we choose to use other hosting platforms in the future, this rollback definition may be more complicated to implement.
+* We are not addressing state, schema management, or infrastructure configuration. When we do, the traffic routing command will need to be wrapped with more complex logic.
+* Service-level Cloud Run configuration such as labels will not be reverted as part of traffic routing.
+
+## Links
+
+* Related User Journeys
+  * [Rollback a bad change](https://github.com/GoogleCloudPlatform/emblem/issues/27)

--- a/docs/decisions/2021-09-testing-service-account.md
+++ b/docs/decisions/2021-09-testing-service-account.md
@@ -1,0 +1,36 @@
+# Create a service account for testing
+
+* **Status:** approved
+* **Last Updated:** 2021-09
+* **Objective:** Provide user identity for API testing
+
+## Context & Problem Statement
+
+The API has both unauthenticated and authenticated resources. How do we provide an identity for authenticated or user-dynamic resources?
+
+## Priorities & Constraints <!-- optional -->
+
+* Tests are driven by Cloud Build, but Cloud Build does not provide a standard Service Identity
+
+## Decision
+
+Create a service account that can be used by the Cloud Build pipelines. Authenticate that service account by providing an identity token to the test code to be injected into requests as needed.
+
+The service account should have as few privileges as possible (ideally, none). It will be used to create ID tokens during test runs. The only thing that will matter for those test runs is the identity provided in the token, not any privileges it has.
+
+Test runs will add the service account's email address as an approver or a campaign manager as needed for the tests to determine that the API is enforcing authorization property.
+
+The service account should not be used in a production deployment, even though the tokens generated for it expire in no more than an hour.
+
+### Further Rationale
+
+The API handler uses standard Google authentication libraries to decode and validate the provided ID token. Those libraries require an ID token created by Google, and check their expiration times. Any IAM account can have an ID token provided to it, and we would not want to create a dummy user account for this purpose. Hence, the decision to use a service account.
+
+### Revisiting this Decision <!-- optional -->
+
+If Cloud Build adds direct support for identity token generation, we will keep the service account but evaluate removing ID Token pre-creation.
+
+## Links
+
+* https://github.com/GoogleCloudPlatform/emblem/pull/151
+* https://github.com/GoogleCloudPlatform/emblem/pull/161

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -22,13 +22,6 @@ Decision records should attempt to follow the Y-statement format for consistency
 In the context of **<use case/user story u>**, facing **<concern c>** we decided for **<option o>** and neglected <other options>, to achieve <system qualities/desired consequences>, accepting <downside d/undesired consequences>, because <additional rationale>.
 ```
 
-## Decision: Rollbacks for Cloud Run use Traffic Splitting
-
-In choosing how to **handle rollbacks for Cloud Run services**, deciding between
-reverting deployments to a previous stable revision and rerouting traffic to a previous known-good revision, we decided to **re-route traffic** for highest recovery speed and least chance of unintended side-effects, accepting this capability is not consistent across all hosting platforms and does not address state management.
-
-* **Date:** 2021/03
-
 ## Decision: Using Cloud Run for Website and Content API
 
 Deciding **which Serverless platform to use for the Website _and_ Content API**, facing the options of **Cloud Functions, App Engine, or Cloud Run**, we decided to **deploy to Cloud Run** for _both_ tasks.  Cloud Run has more flexibility than Cloud Functions or App Engine, and additionally offers concurrency and traffic splitting, allowing for a more natural canary rollout pipeline.
@@ -133,17 +126,3 @@ If a more straightforward and/or more secure method of storing these tokens beco
 (either at the Firebase level, or the HTTP-specification level), we may consider migrating to that option.
 
 (For example, we could do away with the `session` cookie if the Firebase client SDK somehow automatically forwarded a generated ID token to the backend with every request.)
-
-## Decision: Create a service account for testing
-
-The service account should have as few privileges as possible (ideally, none). It will be used to create ID tokens during test runs. The only thing that will matter for those test runs is the identity provided in the token, not any privileges it has.
-
-Test runs will add the service account's email address as an approver or a campaign manager as needed for the tests to determine that the API is enforcing authorization property.
-
-The service account should not be used in a production deployment, even though the tokens generated for it expire in no more than an hour.
-
-### Rationale
-
-The API handler uses standard Google authentication libraries to decode and validate the provided ID token. Those libraries require an ID token created by Google, and check their expiration times. Any IAM account can have an ID token provided to it, and we would not want to create a dummy user account for this purpose. Hence, the decision to use a service account.
-
-* **Date:** 2021/09


### PR DESCRIPTION
Migrate and slightly expand decisions on rollback and testing service account to the new decision record format.