### PR TITLE
feat(ops): provision auth-related Secret Manager entries

### DIFF
--- a/terraform/ops.tf
+++ b/terraform/ops.tf
@@ -185,45 +185,33 @@ resource "google_project_iam_member" "ops_cloudbuild_pubsub_iam_prod" {
 
 # Secret Manager IAM resources
 resource "google_secret_manager_secret_iam_member" "ops_secret_access_iam_prod_client_id" {
-  project   = data.google_project.ops_project.project_id
-  secret_id = "oauth-client-id"
-  role      = "roles/secretmanager.secretAccessor"
-  member    = "serviceAccount:cloud-run-manager@${data.google_project.prod_project.project_id}.iam.gserviceaccount.com"
-  depends_on = [
-    google_project_service.prod_run_api,
-    google_project_service.ops_secretmanager_api
-  ]
+  project    = data.google_project.ops_project.project_id
+  secret_id  = "oauth-client-id"
+  role       = "roles/secretmanager.secretAccessor"
+  member     = "serviceAccount:cloud-run-manager@${data.google_project.prod_project.project_id}.iam.gserviceaccount.com"
+  depends_on = [google_service_account.prod_cloud_run_manager]
 }
 
 resource "google_secret_manager_secret_iam_member" "ops_secret_access_iam_prod_client_secret" {
-  project   = data.google_project.ops_project.project_id
-  secret_id = "oauth-client-secret"
-  role      = "roles/secretmanager.secretAccessor"
-  member    = "serviceAccount:cloud-run-manager@${data.google_project.prod_project.project_id}.iam.gserviceaccount.com"
-  depends_on = [
-    google_project_service.prod_run_api,
-    google_project_service.ops_secretmanager_api
-  ]
+  project    = data.google_project.ops_project.project_id
+  secret_id  = "oauth-client-secret"
+  role       = "roles/secretmanager.secretAccessor"
+  member     = "serviceAccount:cloud-run-manager@${data.google_project.prod_project.project_id}.iam.gserviceaccount.com"
+  depends_on = [google_service_account.prod_cloud_run_manager]
 }
 
 resource "google_secret_manager_secret_iam_member" "ops_secret_access_iam_stage_client_id" {
-  project   = data.google_project.ops_project.project_id
-  secret_id = "oauth-client-id"
-  role      = "roles/secretmanager.secretAccessor"
-  member    = "serviceAccount:cloud-run-manager@${data.google_project.stage_project.project_id}.iam.gserviceaccount.com"
-  depends_on = [
-    google_project_service.stage_run_api,
-    google_project_service.ops_secretmanager_api
-  ]
+  project    = data.google_project.ops_project.project_id
+  secret_id  = "oauth-client-id"
+  role       = "roles/secretmanager.secretAccessor"
+  member     = "serviceAccount:cloud-run-manager@${data.google_project.stage_project.project_id}.iam.gserviceaccount.com"
+  depends_on = [google_service_account.stage_cloud_run_manager]
 }
 
 resource "google_secret_manager_secret_iam_member" "ops_secret_access_iam_stage_client_secret" {
-  project   = data.google_project.ops_project.project_id
-  secret_id = "oauth-client-secret"
-  role      = "roles/secretmanager.secretAccessor"
-  member    = "serviceAccount:cloud-run-manager@${data.google_project.stage_project.project_id}.iam.gserviceaccount.com"
-  depends_on = [
-    google_project_service.stage_run_api,
-    google_project_service.ops_secretmanager_api
-  ]
+  project    = data.google_project.ops_project.project_id
+  secret_id  = "oauth-client-secret"
+  role       = "roles/secretmanager.secretAccessor"
+  member     = "serviceAccount:cloud-run-manager@${data.google_project.stage_project.project_id}.iam.gserviceaccount.com"
+  depends_on = [google_service_account.stage_cloud_run_manager]
 }

--- a/terraform/shared_resources.tf
+++ b/terraform/shared_resources.tf
@@ -54,7 +54,6 @@ resource "google_secret_manager_secret" "client-id-secret" {
   replication {
     automatic = "true"
   }
-  depends_on = [google_project_service.ops_secretmanager_api]
 }
 
 resource "google_secret_manager_secret" "client-secret-secret" {
@@ -63,5 +62,4 @@ resource "google_secret_manager_secret" "client-secret-secret" {
   replication {
     automatic = "true"
   }
-  depends_on = [google_project_service.ops_secretmanager_api]
 }


### PR DESCRIPTION
The secret objects are successfully created; however this has **not** been tested E2E with Cloud Run.

_Relevant decision issue: #240_