### PR TITLE
fix(setup): allow inputs for repo owner and repo name

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -170,10 +170,10 @@ continue=1
 while [[ ${continue} -gt 0 ]]
 do
 
-read -p "Please input the repo-owner [GoogleCloudPlatform]: " repo_owner
-repo_owner=${name:-GoogleCloudPlatform}
+read -p "Please input the repo owner [GoogleCloudPlatform]: " repo_owner
+repo_owner=${repo_owner:-GoogleCloudPlatform}
 read -p "Please input the repo name [emblem]: " repo_name
-repo_name=${name:-emblem}
+repo_name=${repo_name:-emblem}
 
 read -p "Is this the correct repo: ${repo_owner}/${repo_name}? (y/n) " yesno
 


### PR DESCRIPTION
- Fixes inputs for `repo_owner` and `repo_name`
- Corrects the name of the project creation script