### PR TITLE
fix(terraform): increase AR timeout

### DIFF
--- a/terraform/ops/main.tf
+++ b/terraform/ops/main.tf
@@ -63,7 +63,7 @@ resource "time_sleep" "wait_for_artifactregistry" {
   # 
   # For more information, see this GitHub issue:
   # https://github.com/hashicorp/terraform-provider-google/issues/11020
-  create_duration = "10s"
+  create_duration = "20s"
 }
 
 resource "google_artifact_registry_repository" "website_docker" {


### PR DESCRIPTION
The Artifact Registry creation was running into race conditions again.

I bumped up the timeout to 20 seconds, and confirmed that this fixes the issue.

(**Googlers**: see b/217779689 for more context.)