### PR TITLE
feat(issue-339): Adds config ability switch between branded content vs default

### DIFF
--- a/experimental/client-app/package.json
+++ b/experimental/client-app/package.json
@@ -14,7 +14,7 @@
     "analyze": "cem analyze --litelement",
     "lint:css": "stylelint \"src/**/*.js\"",
     "server": "node server/proxy.js",
-    "start": "NODE_ENV=development web-dev-server",
+    "start": "THEME=cymbal NODE_ENV=development web-dev-server",
     "dev": "run-p server start"
   },
   "dependencies": {

--- a/experimental/client-app/server/proxy.js
+++ b/experimental/client-app/server/proxy.js
@@ -23,7 +23,7 @@ const app = express();
 const PORT = 3000;
 const HOST = 'localhost';
 // TODO: Make this configurable for dev/staging/prod
-const API_SERVICE_URL = 'YOUR_API_CONTAINER_URL
+const API_SERVICE_URL = 'https://api-byccf5bkda-uc.a.run.app';
 
 // Logging
 app.use(morgan('dev'));

--- a/experimental/client-app/src/app-shell.js
+++ b/experimental/client-app/src/app-shell.js
@@ -24,12 +24,13 @@ class AppShell extends LitElement {
   static properties = {
     title: { type: String },
   };
-  
   static styles = shellStyles;
 
   constructor() {
     super();
-    this.title = 'Emblem Giving';
+    const { THEME } = getConfig() || {};
+    this.title = THEME === 'cymbal' ? 'Cymbal Giving' : 'Emblem Giving';
+    this.state = { theme: THEME };
   }
 
   firstUpdated() {
@@ -37,9 +38,9 @@ class AppShell extends LitElement {
   }
 
   render() {
-    console.log(getConfig());
+    const { theme } = this.state;
     return html`
-      <app-header></app-header>
+      <app-header .theme=${theme}></app-header>
     `;
   }
 }

--- a/experimental/client-app/src/components/header/header.js
+++ b/experimental/client-app/src/components/header/header.js
@@ -21,12 +21,18 @@ const cloudLogo = new URL('../../../assets/google-cloud-logo.png', import.meta.u
 const cymbalGivingLogo = new URL('../../../assets/cymbal-giving-logo.png', import.meta.url).href;
 
 class Header extends LitElement {
+  static properties = {
+    theme: { type: String },
+  };
   static styles = headerStyles;
-
+  
   render() {
     return html`
       <div class="headerContainer">
-        <img class="cymbalGivingLogo" src=${cymbalGivingLogo}></img>
+        ${this.theme === 'cymbal'
+          ? html`<img class="cymbalGivingLogo" src=${cymbalGivingLogo}></img>` 
+          : html`<div>Emblem Giving</div>`
+        }
         <div class="headerWrapper">
           <div class="cloudLogoWrapper">
             <p>Powered by</p>

--- a/experimental/client-app/src/components/header/styles/header.js
+++ b/experimental/client-app/src/components/header/styles/header.js
@@ -16,11 +16,11 @@ import { css } from 'lit';
 
 const headerStyles =  css`
       .cloudLogo {
-        height: 25px;
+        height: 20px;
       }
 
       .cymbalGivingLogo {
-        height: 100px;
+        height: 90px;
       }
 
       .headerContainer {

--- a/experimental/client-app/src/containers/app-dashboard.js
+++ b/experimental/client-app/src/containers/app-dashboard.js
@@ -56,7 +56,7 @@ class Dashboard extends connect(store)(LitElement) {
       <div class="title">
         Discover a cause or a campaign
       </div>
-      ${content}
+      <div class="dashboardWrapper">${content}</div>
     `;
   }
 }

--- a/experimental/client-app/src/containers/campaign/campaign-page.js
+++ b/experimental/client-app/src/containers/campaign/campaign-page.js
@@ -98,7 +98,7 @@ class CampaignPage extends connect(store)(LitElement) {
               <div class="tabBody"></div>
             </div>
           </div>`
-        ): 'Loading'}
+        ): html`<div>loading...</div>`}
       </div>
     `;
   }

--- a/experimental/client-app/src/containers/campaign/styles/campaignPage.js
+++ b/experimental/client-app/src/containers/campaign/styles/campaignPage.js
@@ -40,7 +40,7 @@ const campaignPage =  css`
     .campaignContainer {
       display: flex;
       align-items: center;
-      justify-content: space-between;
+      justify-content: center;
       margin: 30px auto;
       font-family: "Google Sans";
       width: 100%;

--- a/experimental/client-app/src/styles/shell.js
+++ b/experimental/client-app/src/styles/shell.js
@@ -39,6 +39,12 @@ const shellStyles =  css`
     width: 100%;
     padding: 30px;
   }
+
+  .dashboardWrapper {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+  }
 `;
 /* stylelint-enable font-family-no-missing-generic-family-keyword */
 

--- a/experimental/client-app/src/utils/config.js
+++ b/experimental/client-app/src/utils/config.js
@@ -14,6 +14,6 @@
 
 export const getConfig = () => ({
     NODE_ENV: '__env__',
-    API_URL: '__api_url__'
-  });
-
+    API_URL: '__api_url__',
+    THEME: '__theme__'
+});

--- a/experimental/client-app/web-dev-server.config.mjs
+++ b/experimental/client-app/web-dev-server.config.mjs
@@ -19,20 +19,21 @@ const replace = fromRollup(rollupReplace);
 const hmr = process.argv.includes('--hmr');
 const env = process.env.NODE_ENV;
 const isFlaskProxy = process.env.FLASK_PROXY;
-
+const theme = process.env.THEME;
 
 export default /** @type {import('@web/dev-server').DevServerConfig} */ ({
   open: '/',
   watch: !hmr,
   /** Resolve bare module imports */
   nodeResolve: {
-exportConditions: ['browser', 'development']
+    exportConditions: ['browser', 'development']
   },
   plugins: [
     replace({
       include: ['src/utils/config.js'],
       preventAssignment: false,
       '__env__': env || 'development',
+      '__theme__': theme || 'default', // one of cymbal or default
       '__api_url__': isFlaskProxy ? 'http://127.0.0.1:5000/api/v1' : 'http://localhost:3000'
     }),
   ]


### PR DESCRIPTION
Depends on #352 to be merged first.
Resolves issue: #339 

To verify locally:
* Replace string in line 26 with your api container url (`experimental/client-app/server/proxy.js`)
```
npm i
npm run build
npm run dev
```

See that the header changes according to `THEME` environment variable hardcoded in `package.json`. Currently just 2 options: `cymbal` branding and default emblem branding. 
