### PR TITLE
testing: convert conventional commit PR titles to labels

### DIFF
--- a/.github/workflows/auto-label.yml
+++ b/.github/workflows/auto-label.yml
@@ -1,0 +1,35 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the 'License');
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an 'AS IS' BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: Auto Label
+on:
+  pull_request_target:
+    types: [ opened, edited ]
+
+# Add labels to Pull Requests
+permissions:
+  issues: write
+  pull-requests: write
+
+jobs:
+  conventional-release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Conventional Release Labels
+        uses: bcoe/conventional-release-labels@v1
+        with:
+          type_labels:
+            feat: 'type: feature request'
+            fix: 'type: bug'
+            breaking: 'semver: major'


### PR DESCRIPTION
This is part of #360. It lifts conventional commit prefixes from PR titles to labels, where the GitHub release notes can pick up things like breaking changes per the configuration in #382. These labels also help ensure the write labels are on the PRs, avoiding metadata gaps or manual work where the prefixes are used correctly.