### PR TITLE
feat(setup.sh): add skips for non-automated processes

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -21,7 +21,7 @@
 #   PROD_PROJECT            GCP Project ID of the production project
 #   STAGE_PROJECT           GCP Project ID of the staging project
 #   OPS_PROJECT             GCP Project ID of the operations project
-#   SKIP_REPO_CONNECTION    If set, don't prompt for repo connection + custom repo details
+#   SKIP_TRIGGERS           If set, don't set up build triggers
 #   SKIP_AUTH               If set, don't set up auth
 #   REPO_OWNER              GitHub user/organization name (default: GoogleCloudPlatform)
 #   REPO_NAME               GitHub repo name (default: emblem)
@@ -188,7 +188,7 @@ fi
 # Set up CI/CD #
 ################
 
-if [[ -z "${SKIP_REPO_CONNECTION}" ]]; then
+if [[ -z "${SKIP_TRIGGERS}" ]]; then
     REPO_CONNECT_URL="https://console.cloud.google.com/cloud-build/triggers/connect?\
     project=${OPS_PROJECT}"
     echo "Connect your repos: ${REPO_CONNECT_URL}"

--- a/setup.sh
+++ b/setup.sh
@@ -17,6 +17,15 @@
 # This will require 3 projects, for ops, staging, and prod
 # To auto-create the projects, run clean_project_setup.sh
 
+# Variable list
+#   PROD_PROJECT            GCP Project ID of the production project
+#   STAGE_PROJECT           GCP Project ID of the staging project
+#   OPS_PROJECT             GCP Project ID of the operations project
+#   SKIP_REPO_CONNECTION    If set, don't prompt for repo connection + custom repo details
+#   SKIP_AUTH               If set, don't set up auth
+#   REPO_OWNER              GitHub user/organization name (default: GoogleCloudPlatform)
+#   REPO_NAME               GitHub repo name (default: emblem)
+
 set -eu
 
 # Check env variables are not empty strings
@@ -204,23 +213,23 @@ if [[ -z "${SKIP_REPO_CONNECTION}" ]]; then
         fi
 
     done
-fi
 
-###################
-# Create Triggers #
-###################
+    ###################
+    # Create Triggers #
+    ###################
 
-pushd terraform/ops/triggers
-# Set Trigger Variables
-cat > terraform.tfvars <<EOF
+    pushd terraform/ops/triggers
+    # Set Trigger Variables
+    cat > terraform.tfvars <<EOF
 google_ops_project_id = "${OPS_PROJECT}"
 repo_owner = "${repo_owner}"
 repo_name = "${repo_name}"
 EOF
 
-terraform init
-terraform apply --auto-approve
-popd
+    terraform init
+    terraform apply --auto-approve
+    popd
 
-export GITHUB_URL="https://github.com/${repo_owner}/${repo_name}"
-sh ./scripts/pubsub_triggers.sh
+    export GITHUB_URL="https://github.com/${repo_owner}/${repo_name}"
+    sh ./scripts/pubsub_triggers.sh
+fi

--- a/setup.sh
+++ b/setup.sh
@@ -158,48 +158,53 @@ website
 ###############
 # Set up auth #
 ###############
-echo ""
-read -p "Would you like to configure $(tput bold)$(tput setaf 3)end-user authentication?$(tput sgr0) (y/n) " auth_yesno
+if [[ -z "${SKIP_AUTH}" ]]; then
+    echo ""
+    read -p "Would you like to configure $(tput bold)$(tput setaf 3)end-user authentication?$(tput sgr0) (y/n) " auth_yesno
 
-if [[ ${auth_yesno} == "y" ]]; then
-    sh ./scripts/configure_auth.sh
-else
-    echo "Skipping end-user authentication configuration. You can configure it later by running:"
-    echo ""
-    echo "  export $(tput bold)PROD_PROJECT$(tput sgr0)=$(tput setaf 6)${PROD_PROJECT}$(tput sgr0)"
-    echo "  export $(tput bold)STAGE_PROJECT$(tput sgr0)=$(tput setaf 6)${STAGE_PROJECT}$(tput sgr0)"
-    echo "  export $(tput bold)OPS_PROJECT$(tput sgr0)=$(tput setaf 6)${OPS_PROJECT}$(tput sgr0)"
-    echo "  $(tput setaf 6)sh scripts/configure_auth.sh$(tput sgr0)"
-    echo ""
+    if [[ ${auth_yesno} == "y" ]]; then
+        sh ./scripts/configure_auth.sh
+    else
+        echo "Skipping end-user authentication configuration. You can configure it later by running:"
+        echo ""
+        echo "  export $(tput bold)PROD_PROJECT$(tput sgr0)=$(tput setaf 6)${PROD_PROJECT}$(tput sgr0)"
+        echo "  export $(tput bold)STAGE_PROJECT$(tput sgr0)=$(tput setaf 6)${STAGE_PROJECT}$(tput sgr0)"
+        echo "  export $(tput bold)OPS_PROJECT$(tput sgr0)=$(tput setaf 6)${OPS_PROJECT}$(tput sgr0)"
+        echo "  $(tput setaf 6)sh scripts/configure_auth.sh$(tput sgr0)"
+        echo ""
+    fi
 fi
 
 ################
 # Set up CI/CD #
 ################
 
-REPO_CONNECT_URL="https://console.cloud.google.com/cloud-build/triggers/connect?\
-project=${OPS_PROJECT}"
-echo "Connect your repos: ${REPO_CONNECT_URL}"
-python3 -m webbrowser ${REPO_CONNECT_URL}
+if [[ -z "${SKIP_REPO_CONNECTION}" ]]; then
+    REPO_CONNECT_URL="https://console.cloud.google.com/cloud-build/triggers/connect?\
+    project=${OPS_PROJECT}"
+    echo "Connect your repos: ${REPO_CONNECT_URL}"
 
-read -p "Once your repo is connected, please continue by typing any key."
+    python3 -m webbrowser ${REPO_CONNECT_URL}
 
-continue=1
-while [[ ${continue} -gt 0 ]]
-do
+    read -p "Once your repo is connected, please continue by typing any key."
 
-read -p "Please input the repo owner [GoogleCloudPlatform]: " repo_owner
-repo_owner=${repo_owner:-GoogleCloudPlatform}
-read -p "Please input the repo name [emblem]: " repo_name
-repo_name=${repo_name:-emblem}
+    continue=1
+    while [[ ${continue} -gt 0 ]]
+    do
 
-read -p "Is this the correct repo: ${repo_owner}/${repo_name}? (y/n) " yesno
+        read -p "Please input the repo owner [GoogleCloudPlatform]: " repo_owner
+        repo_owner=${repo_owner:-GoogleCloudPlatform}
+        read -p "Please input the repo name [emblem]: " repo_name
+        repo_name=${repo_name:-emblem}
 
-if [[ ${yesno} == "y" ]]
-then continue=0
+        read -p "Is this the correct repo: ${repo_owner}/${repo_name}? (y/n) " yesno
+
+        if [[ ${yesno} == "y" ]]
+            then continue=0
+        fi
+
+    done
 fi
-
-done
 
 ###################
 # Create Triggers #


### PR DESCRIPTION
Setting the stage for future work on automated **Delivery** testing.

This adds two environment variables to `setup.sh`:
- `SKIP_AUTH`
- `SKIP_TRIGGERS`

Setting these environment variables will enable _programmatic deployments_ of Emblem using `setup.sh`.