### PR TITLE
chore(ops): use UBLA buckets

### DIFF
--- a/terraform/app/application/main.tf
+++ b/terraform/app/application/main.tf
@@ -88,8 +88,11 @@ resource "google_app_engine_application" "main" {
 resource "google_storage_bucket" "sessions" {
   name                        = "${data.google_project.main.project_id}-sessions"
   force_destroy               = true
-  uniform_bucket_level_access = true
   location                    = var.region
+  
+  # Enable uniform bucket-level access to prevent overly lenient per-file permissions
+  # (Also, some GCP organization policies require this as a security measure.)
+  uniform_bucket_level_access = true
 
   # Delete files after configured time.
   # (These buckets will contain end-user data, so periodic deletion is a best practice.)

--- a/terraform/app/application/main.tf
+++ b/terraform/app/application/main.tf
@@ -86,9 +86,10 @@ resource "google_app_engine_application" "main" {
 # Objects created in this bucket represent a new user session.
 # A user may have more than one session, representing different authenticated applications/devices.
 resource "google_storage_bucket" "sessions" {
-  name          = "${data.google_project.main.project_id}-sessions"
-  force_destroy = true
-  location      = var.region
+  name                        = "${data.google_project.main.project_id}-sessions"
+  force_destroy               = true
+  uniform_bucket_level_access = true
+  location                    = var.region
 
   # Delete files after configured time.
   # (These buckets will contain end-user data, so periodic deletion is a best practice.)

--- a/terraform/app/application/main.tf
+++ b/terraform/app/application/main.tf
@@ -86,10 +86,10 @@ resource "google_app_engine_application" "main" {
 # Objects created in this bucket represent a new user session.
 # A user may have more than one session, representing different authenticated applications/devices.
 resource "google_storage_bucket" "sessions" {
-  name                        = "${data.google_project.main.project_id}-sessions"
-  force_destroy               = true
-  location                    = var.region
-  
+  name          = "${data.google_project.main.project_id}-sessions"
+  force_destroy = true
+  location      = var.region
+
   # Enable uniform bucket-level access to prevent overly lenient per-file permissions
   # (Also, some GCP organization policies require this as a security measure.)
   uniform_bucket_level_access = true


### PR DESCRIPTION
This is required to comply with [UBLA-only](https://cloud.google.com/storage/docs/uniform-bucket-level-access) GCS policies.