### PR TITLE
refactor(docs): Adding in website deployment section + fixes

### DIFF
--- a/content-api/README.md
+++ b/content-api/README.md
@@ -57,8 +57,7 @@ the first approver:
     `active` of type boolean, and value true.
     - Click *Save*
 
-The person with this email address will be able to perform
-all API operations as an Approver.
+The person with this email address will be able to perform all API operations as an Approver.
 
 ### Deploy the API server to Cloud Run
 

--- a/scripts/configure_auth.sh
+++ b/scripts/configure_auth.sh
@@ -103,10 +103,13 @@ else
     echo "  Visit this URL in the Cloud Console: $(tput bold)${SECRETS_URL}$(tput sgr0)"
 fi
 echo ""
-echo "  Open the $(tput bold)client_id_secret$(tput sgr0) and click +NEW VERSION. "
+echo "  Create a secret by clicking +CREATE SECRET and name it $(tput bold)client_id_secret$(tput sgr0)."
+echo "  If the secret already exists, open $(tput bold)client_id_secret$(tput sgr0) and click +NEW VERSION. "
 echo "  In the $(tput bold)Secret value$(tput sgr0) field, enter the $(tput bold)client ID$(tput sgr0) from the previous step. "
 echo "  Click $(tput bold)Add new version$(tput sgr0)."
+echo "                                                "
 echo "  Repeat the steps above for $(tput bold)client_secret_secret$(tput sgr0)."
+echo "  In the $(tput bold)Secret value$(tput sgr0) field, enter the $(tput bold)client secret$(tput sgr0) from the previous step. "
 echo ""
 if [[ $CLOUD_SHELL ]]; then
     echo ""

--- a/website/README.md
+++ b/website/README.md
@@ -32,7 +32,7 @@ To enable end-user authentication within the application, see the [Website compo
 ### Configuration
 To configure the Emblem website, see the [Website component's detailed documentation](../docs/website.md#configuration).
 
-### Run flask app locally
+### Running the Flask app locally
 
 To run the website locally, use the `flask run` command. By default, the website will run on port `8080`.
 

--- a/website/README.md
+++ b/website/README.md
@@ -63,9 +63,31 @@ The `EMBLEM_API_URL` value will be determined by where you host the Content API.
 
 Congratulations! You are now ready to run the Emblem web app.
 
-### Running
+### Run flask app locally
 
 To run the website locally, use the `flask run` command. By default, the website will run on port `8080`.
+
+### Deploy the website container to Cloud Run
+
+1. Navigate to the directory `website/`.
+2. Copy the `client-libs/` directory located in root folder
+```
+cp -rf ../client-libs/ .
+```
+3. Create an environment variable that contains your API server url and your Emblem session bucket name.
+```
+export SITE_VARS="EMBLEM_API_URL=$EMBLEM_API_URL, EMBLEM_SESSION_BUCKET=${EMBLEM_SESSION_BUCKET}"
+```
+4. Build an image with Cloud Build
+```
+gcloud builds submit . --tag=gcr.io/$PROJECT_ID/website
+```
+5. Deploy to Cloud Run
+```
+gcloud run deploy --image=gcr.io/$PROJECT_ID/website --set-env-vars "$SITE_VARS" website
+```
+
+Navigate to the URI provided upon successful deployment.
 
 ## Seed Database
 To mimic a real-world production instance, you can deploy the [Content API](../content-api/README.md) and seed the Firestore database with sample data. Add fake campaigns, causes, donors, and donations by running the [`seed_database`](../content-api/data/seed_database.py) script:

--- a/website/templates/errors/403.html
+++ b/website/templates/errors/403.html
@@ -21,4 +21,3 @@
 {% block error_message %}Error 403: Access Denied{% endblock %}
 
 {% block error_caption %}You do not have access to this resource.{% endblock %}
-{% endblock %}


### PR DESCRIPTION
Issue: #370 

Resolves the following:
* Minor clarification for client id, client secret instructions
* Adding website deployment instructions explicitly in website readme
* Fix flask 403 template bug (seen when you authenticate as a wrong user into the app)