### PR TITLE
fix: auto-labeler YAML syntax error

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -16,44 +16,44 @@
 
 # component labels are used in release notes.
 'component: website':
-- website/*
-- website/**/*
-- client-libs/*
-- client-libs/**/*
+- 'website/*'
+- 'website/**/*'
+- 'client-libs/*'
+- 'client-libs/**/*'
 'component: content-api':
-- content-api/*
-- content-api/**/*
-- client-libs/*
-- client-libs/**/*
+- 'content-api/*'
+- 'content-api/**/*'
+- 'client-libs/*'
+- 'client-libs/**/*'
 'component: delivery':
-- terraform/*
-- terraform/**/*
-- ops/*
-- ops/**/*
-- scripts/*
-- scripts/**/*
-- setup.sh
+- 'terraform/*'
+- 'terraform/**/*'
+- 'ops/*'
+- 'ops/**/*'
+- 'scripts/*'
+- 'scripts/**/*'
+- 'setup.sh'
 'component: demo services':
-- docs/*
-- docs/**/*
-- content-api/data/*
-- content-api/data/**/*
+- 'docs/*'
+- 'docs/**/*'
+- 'content-api/data/*'
+- 'content-api/data/**/*'
 
 # The following labels are under general use evaluation.
 
-documentation:
+'documentation':
 - '**/*.md'
-- docs/*
-- docs/**/*
+- 'docs/*'
+- 'docs/**/*'
 
 'tech: gha':
-- .github/workflows/*
-- .github/labeler.yml
-- .github/release.yml
+- '.github/workflows/*'
+- '.github/labeler.yml'
+- '.github/release.yml'
 
 'persona: maintainer':
-- *.md
-- CODEOWNERS
-- .git*
-- .github/*
-- .github/**/*
+- '*.md'
+- 'CODEOWNERS'
+- '.git*'
+- '.github/*'
+- '.github/**/*'


### PR DESCRIPTION
Working my way through syntax errors. This was a parsing error in labeler.yml: `Error: YAMLException: unidentified alias ".md" (55:7)`. To address this, I'm wrapping all strings in quote marks.