### PR TITLE
fix(content-api): update Flask version

### DIFF
--- a/content-api/requirements.txt
+++ b/content-api/requirements.txt
@@ -1,4 +1,4 @@
-flask==2.0.1
+flask==2.1.1
 google-cloud-firestore==2.1.3
 gunicorn==20.1.0
 google.auth==1.34.0


### PR DESCRIPTION
This [_should_](https://stackoverflow.com/questions/71661851/typeerror-init-got-an-unexpected-keyword-argument-as-tuple) fix #393.