### PR TITLE
feat(terraform): integrate modular terraform

### DIFF
--- a/experimental-setup.sh
+++ b/experimental-setup.sh
@@ -124,10 +124,15 @@ if [[ -z "$SKIP_TRIGGERS" ]]; then
     export TF_VAR_deploy_triggers="true"
     export TF_VAR_repo_name=${REPO_NAME}
     export TF_VAR_repo_owner=${REPO_OWNER}
-    terraform -chdir=${OPS_ENVIRONMENT_DIR} apply
+    terraform -chdir=${OPS_ENVIRONMENT_DIR} apply --auto-approve
+    # Call via shell until Terraform integration
+    # Setting legacy env variables
+    export GITHUB_URL=https://github.com/$REPO_OWNER/$REPO_NAME
+    export STAGE_PROJECT=$STAGING_PROJECT_ID
+    export OPS_PROJECT=$OPS_PROJECT_ID
+    export PROD_PROJECT=$PROD_PROJECT_ID
+    sh ./scripts/pubsub_triggers.sh
 fi
-
-# TODO: Add pubsub_triggers.sh
 
 ## Set up auth ##
 
@@ -140,9 +145,9 @@ if [[ -z "$SKIP_AUTH" ]]; then
     else
         echo "Skipping end-user authentication configuration. You can configure it later by running:"
         echo ""
-        echo "  export $(tput bold)PROD_PROJECT$(tput sgr0)=$(tput setaf 6)${PROD_PROJECT}$(tput sgr0)"
-        echo "  export $(tput bold)STAGING_PROJECT$(tput sgr0)=$(tput setaf 6)${STAGING_PROJECT}$(tput sgr0)"
-        echo "  export $(tput bold)OPS_PROJECT$(tput sgr0)=$(tput setaf 6)${OPS_PROJECT}$(tput sgr0)"
+        echo "  export $(tput bold)PROD_PROJECT$(tput sgr0)=$(tput setaf 6)${PROD_PROJECT_ID}$(tput sgr0)"
+        echo "  export $(tput bold)STAGING_PROJECT$(tput sgr0)=$(tput setaf 6)${STAGING_PROJECT_ID}$(tput sgr0)"
+        echo "  export $(tput bold)OPS_PROJECT$(tput sgr0)=$(tput setaf 6)${OPS_PROJECT_ID}$(tput sgr0)"
         echo "  $(tput setaf 6)sh scripts/configure_auth.sh$(tput sgr0)"
         echo ""
     fi

--- a/experimental-setup.sh
+++ b/experimental-setup.sh
@@ -17,10 +17,12 @@ set -eu
 
 # Variable list
 #   PROD_PROJECT_ID         GCP Project ID of the production project
-#   STAGING_PROJECT_ID           GCP Project ID of the staging project
-#   OPS_PROJECT_ID             GCP Project ID of the operations project
+#   STAGING_PROJECT_ID      GCP Project ID of the staging project
+#   OPS_PROJECT_ID          GCP Project ID of the operations project
 #   SKIP_TRIGGERS           If set, don't set up build triggers
 #   SKIP_AUTH               If set, do not prompt to set up auth
+
+export SKIP_TRIGGERS="true" # Force SKIP_TRIGGERS until fully integrated into Terraform ops module
 
 ## Ops Project (minus triggers) ##
 

--- a/experimental-setup.sh
+++ b/experimental-setup.sh
@@ -100,6 +100,11 @@ gcloud run deploy --allow-unauthenticated \
 
 ## Deploy Triggers to Ops Project ##
 
+### Set legacy env variables
+export STAGE_PROJECT=$STAGING_PROJECT_ID
+export OPS_PROJECT=$OPS_PROJECT_ID
+export PROD_PROJECT=$PROD_PROJECT_ID
+
 if [[ -z "$SKIP_TRIGGERS" ]]; then
     REPO_CONNECT_URL="https://console.cloud.google.com/cloud-build/triggers/connect?project=${OPS_PROJECT_ID}"
     echo "Connect your repos: ${REPO_CONNECT_URL}"
@@ -125,12 +130,9 @@ if [[ -z "$SKIP_TRIGGERS" ]]; then
     export TF_VAR_repo_name=${REPO_NAME}
     export TF_VAR_repo_owner=${REPO_OWNER}
     terraform -chdir=${OPS_ENVIRONMENT_DIR} apply --auto-approve
+    
     # Call via shell until Terraform integration
-    # Setting legacy env variables
     export GITHUB_URL=https://github.com/$REPO_OWNER/$REPO_NAME
-    export STAGE_PROJECT=$STAGING_PROJECT_ID
-    export OPS_PROJECT=$OPS_PROJECT_ID
-    export PROD_PROJECT=$PROD_PROJECT_ID
     sh ./scripts/pubsub_triggers.sh
 fi
 

--- a/experimental-setup.sh
+++ b/experimental-setup.sh
@@ -1,0 +1,148 @@
+#!/bin/bash
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -eu
+
+# Variable list
+#   PROD_PROJECT_ID         GCP Project ID of the production project
+#   STAGING_PROJECT_ID           GCP Project ID of the staging project
+#   OPS_PROJECT_ID             GCP Project ID of the operations project
+#   SKIP_TRIGGERS           If set, don't set up build triggers
+#   SKIP_AUTH               If set, do not prompt to set up auth
+
+## Ops Project (minus triggers) ##
+
+OPS_ENVIRONMENT_DIR=terraform/environments/ops
+export TF_VAR_project_id=${OPS_PROJECT_ID}
+terraform -chdir=${OPS_ENVIRONMENT_DIR} init
+terraform -chdir=${OPS_ENVIRONMENT_DIR} apply
+
+## Staging Project ##
+
+STAGING_ENVIRONMENT_DIR=terraform/environments/staging
+export TF_VAR_project_id=${STAGING_PROJECT_ID}
+export TF_VAR_ops_project_id=${OPS_PROJECT_ID}
+
+terraform -chdir=${STAGING_ENVIRONMENT_DIR} init
+terraform -chdir=${STAGING_ENVIRONMENT_DIR} apply
+
+## Prod Project ##
+
+PROD_ENVIRONMENT_DIR=terraform/environments/prod
+export TF_VAR_project_id=${PROD_PROJECT_ID}
+export TF_VAR_ops_project_id=${OPS_PROJECT_ID}
+
+terraform -chdir=${PROD_ENVIRONMENT_DIR} init
+terraform -chdir=${PROD_ENVIRONMENT_DIR} apply
+
+## Build Containers ##
+
+export REGION="us-central1"
+SHORT_SHA="setup"
+E2E_RUNNER_TAG="latest"
+
+gcloud builds submit --config=ops/api-build.cloudbuild.yaml \
+    --project="$OPS_PROJECT_ID" --substitutions=_REGION="$REGION",SHORT_SHA="$SHORT_SHA"
+
+gcloud builds submit --config=ops/web-build.cloudbuild.yaml \
+    --project="$OPS_PROJECT_ID" --substitutions=_REGION="$REGION",SHORT_SHA="$SHORT_SHA"
+
+gcloud builds submit --config=ops/e2e-runner-build.cloudbuild.yaml \
+    --project="$OPS_PROJECT_ID" --substitutions=_REGION="$REGION",_IMAGE_TAG="$E2E_RUNNER_TAG"
+
+## Prod Services ##
+
+gcloud run deploy --allow-unauthenticated \
+    --image "${REGION}-docker.pkg.dev/${OPS_PROJECT_ID}/content-api/content-api:${SHORT_SHA}" \
+    --project "$PROD_PROJECT_ID" --service-account "api-manager@${PROD_PROJECT_ID}.iam.gserviceaccount.com" \
+    --region "${REGION}" content-api
+
+PROD_API_URL=$(gcloud run services describe content-api --project ${PROD_PROJECT_ID} --region ${REGION} --format "value(status.url)")
+WEBSITE_VARS="EMBLEM_SESSION_BUCKET=${PROD_PROJECT_ID}-sessions"
+WEBSITE_VARS="${WEBSITE_VARS},EMBLEM_API_URL=${PROD_API_URL}"
+
+gcloud run deploy --allow-unauthenticated \
+    --image "${REGION}-docker.pkg.dev/${OPS_PROJECT_ID}/website/website:${SHORT_SHA}" \
+    --project "$PROD_PROJECT_ID" --service-account "website-manager@${PROD_PROJECT_ID}.iam.gserviceaccount.com" \
+    --set-env-vars "$WEBSITE_VARS" --region "${REGION}" --tag "latest" \
+    website
+
+## Staging Services ##
+
+gcloud run deploy --allow-unauthenticated \
+    --image "${REGION}-docker.pkg.dev/${OPS_PROJECT_ID}/content-api/content-api:${SHORT_SHA}" \
+    --project "$STAGING_PROJECT_ID" --service-account "api-manager@${STAGING_PROJECT_ID}.iam.gserviceaccount.com" \
+    --region "${REGION}" content-api
+
+STAGING_API_URL=$(gcloud run services describe content-api --project ${STAGING_PROJECT_ID} --region ${REGION} --format "value(status.url)")
+
+WEBSITE_VARS="EMBLEM_SESSION_BUCKET=${STAGING_PROJECT_ID}-sessions"
+WEBSITE_VARS="${WEBSITE_VARS},EMBLEM_API_URL=${STAGING_API_URL}"
+
+gcloud run deploy --allow-unauthenticated \
+    --image "${REGION}-docker.pkg.dev/${OPS_PROJECT_ID}/website/website:${SHORT_SHA}" \
+    --project "$STAGING_PROJECT_ID" --service-account "website-manager@${STAGING_PROJECT_ID}.iam.gserviceaccount.com" \
+    --set-env-vars "$WEBSITE_VARS" --region "${REGION}" --tag "latest" \
+    website
+
+## Deploy Triggers to Ops Project ##
+
+if [[ -z "$SKIP_TRIGGERS" ]]; then
+    REPO_CONNECT_URL="https://console.cloud.google.com/cloud-build/triggers/connect?project=${OPS_PROJECT_ID}"
+    echo "Connect your repos: ${REPO_CONNECT_URL}"
+    read -p "Once your repo is connected, please continue by typing any key."
+    continue=1
+    while [[ ${continue} -gt 0 ]]; do
+
+        read -p "Please input the repo owner [GoogleCloudPlatform]: " REPO_OWNER
+        repo_owner=${repo_owner:-GoogleCloudPlatform}
+        read -p "Please input the repo name [emblem]: " REPO_NAME
+        repo_name=${repo_name:-emblem}
+
+        read -p "Is this the correct repo: ${REPO_OWNER}/${REPO_NAME}? (y/n) " yesno
+
+        if [[ ${yesno} == "y" ]]; then
+            continue=0
+        fi
+
+    done
+
+    export TF_VAR_project_id=${OPS_PROJECT_ID}
+    export TF_VAR_deploy_triggers="true"
+    export TF_VAR_repo_name=${REPO_NAME}
+    export TF_VAR_repo_owner=${REPO_OWNER}
+    terraform -chdir=${OPS_ENVIRONMENT_DIR} apply
+fi
+
+# TODO: Add pubsub_triggers.sh
+
+## Set up auth ##
+
+if [[ -z "$SKIP_AUTH" ]]; then
+    echo ""
+    read -p "Would you like to configure $(tput bold)$(tput setaf 3)end-user authentication?$(tput sgr0) (y/n) " auth_yesno
+
+    if [[ ${auth_yesno} == "y" ]]; then
+        sh ./scripts/configure_auth.sh
+    else
+        echo "Skipping end-user authentication configuration. You can configure it later by running:"
+        echo ""
+        echo "  export $(tput bold)PROD_PROJECT$(tput sgr0)=$(tput setaf 6)${PROD_PROJECT}$(tput sgr0)"
+        echo "  export $(tput bold)STAGING_PROJECT$(tput sgr0)=$(tput setaf 6)${STAGING_PROJECT}$(tput sgr0)"
+        echo "  export $(tput bold)OPS_PROJECT$(tput sgr0)=$(tput setaf 6)${OPS_PROJECT}$(tput sgr0)"
+        echo "  $(tput setaf 6)sh scripts/configure_auth.sh$(tput sgr0)"
+        echo ""
+    fi
+fi

--- a/experimental-setup.sh
+++ b/experimental-setup.sh
@@ -26,8 +26,9 @@ set -eu
 
 OPS_ENVIRONMENT_DIR=terraform/environments/ops
 export TF_VAR_project_id=${OPS_PROJECT_ID}
+export TF_VAR_environment_project_ids="{\"prod\" = \"${PROD_PROJECT_ID}\", \"staging\" = \"${STAGING_PROJECT_ID}\"}"
 terraform -chdir=${OPS_ENVIRONMENT_DIR} init
-terraform -chdir=${OPS_ENVIRONMENT_DIR} apply
+terraform -chdir=${OPS_ENVIRONMENT_DIR} apply --auto-approve
 
 ## Staging Project ##
 
@@ -36,7 +37,7 @@ export TF_VAR_project_id=${STAGING_PROJECT_ID}
 export TF_VAR_ops_project_id=${OPS_PROJECT_ID}
 
 terraform -chdir=${STAGING_ENVIRONMENT_DIR} init
-terraform -chdir=${STAGING_ENVIRONMENT_DIR} apply
+terraform -chdir=${STAGING_ENVIRONMENT_DIR} apply --auto-approve
 
 ## Prod Project ##
 
@@ -45,7 +46,7 @@ export TF_VAR_project_id=${PROD_PROJECT_ID}
 export TF_VAR_ops_project_id=${OPS_PROJECT_ID}
 
 terraform -chdir=${PROD_ENVIRONMENT_DIR} init
-terraform -chdir=${PROD_ENVIRONMENT_DIR} apply
+terraform -chdir=${PROD_ENVIRONMENT_DIR} apply --auto-approve
 
 ## Build Containers ##
 

--- a/terraform/environments/ops/main.tf
+++ b/terraform/environments/ops/main.tf
@@ -1,0 +1,9 @@
+module "emblem_ops" {
+  source                  = "../../modules/ops"
+  project_id              = var.project_id
+  region                  = var.region
+  deploy_triggers         = var.deploy_triggers
+  repo_owner              = var.repo_owner
+  repo_name               = var.repo_name
+  environment_project_ids = var.environment_project_ids
+}

--- a/terraform/environments/ops/variables.tf
+++ b/terraform/environments/ops/variables.tf
@@ -10,9 +10,9 @@ variable "region" {
 }
 
 variable "deploy_triggers" {
-  type = bool
-  default = false
-  description = ""  
+  type        = bool
+  default     = false
+  description = ""
 }
 
 variable "repo_owner" {
@@ -28,6 +28,6 @@ variable "repo_name" {
 }
 
 variable "environment_project_ids" {
-  type = map(string)
+  type        = map(string)
   description = "Map containing environment names and project IDs"
 }

--- a/terraform/environments/ops/variables.tf
+++ b/terraform/environments/ops/variables.tf
@@ -1,0 +1,33 @@
+variable "project_id" {
+  type        = string
+  description = ""
+}
+
+variable "region" {
+  type        = string
+  default     = "us-central1"
+  description = ""
+}
+
+variable "deploy_triggers" {
+  type = bool
+  default = false
+  description = ""  
+}
+
+variable "repo_owner" {
+  type        = string
+  description = ""
+  default     = ""
+}
+
+variable "repo_name" {
+  type        = string
+  description = ""
+  default     = ""
+}
+
+variable "environment_project_ids" {
+  type = map(string)
+  description = "Map containing environment names and project IDs"
+}

--- a/terraform/environments/prod/main.tf
+++ b/terraform/environments/prod/main.tf
@@ -1,0 +1,8 @@
+module "emblem_prod" {
+  source                  = "../../modules/emblem-app"
+  project_id              = var.project_id
+  ops_project_id          = var.ops_project_id
+  region                  = var.region
+  enable_apis             = var.enable_apis
+  session_bucket_ttl_days = var.session_bucket_ttl_days
+}

--- a/terraform/environments/prod/variables.tf
+++ b/terraform/environments/prod/variables.tf
@@ -1,0 +1,27 @@
+variable "project_id" {
+  type        = string
+  description = "Project ID of project to deploy resources to."
+}
+
+variable "region" {
+  type        = string
+  description = "Region to deploy resources to."
+  default     = "us-central1"
+}
+
+variable "enable_apis" {
+  type        = bool
+  description = "Toggle to include required APIs."
+  default     = true
+}
+
+variable "session_bucket_ttl_days" {
+  type        = number
+  description = "Number of days before session bucket data is deleted."
+  default     = 14
+}
+
+variable "ops_project_id" {
+  type        = string
+  description = "Project ID of Emblem ops project."
+}

--- a/terraform/environments/staging/main.tf
+++ b/terraform/environments/staging/main.tf
@@ -1,0 +1,8 @@
+module "emblem_staging" {
+  source                  = "../../modules/emblem-app"
+  project_id              = var.project_id
+  ops_project_id          = var.ops_project_id
+  region                  = var.region
+  enable_apis             = var.enable_apis
+  session_bucket_ttl_days = var.session_bucket_ttl_days
+}

--- a/terraform/environments/staging/variables.tf
+++ b/terraform/environments/staging/variables.tf
@@ -1,0 +1,27 @@
+variable "project_id" {
+  type        = string
+  description = "Project ID of project to deploy resources to."
+}
+
+variable "region" {
+  type        = string
+  description = "Region to deploy resources to."
+  default     = "us-central1"
+}
+
+variable "enable_apis" {
+  type        = bool
+  description = "Toggle to include required APIs."
+  default     = true
+}
+
+variable "session_bucket_ttl_days" {
+  type        = number
+  description = "Number of days before session bucket data is deleted."
+  default     = 14
+}
+
+variable "ops_project_id" {
+  type        = string
+  description = "Project ID of Emblem ops project."
+}

--- a/terraform/modules/emblem-app/iam.tf
+++ b/terraform/modules/emblem-app/iam.tf
@@ -1,0 +1,61 @@
+resource "google_service_account" "cloud_run_manager" {
+  project      = var.project_id
+  account_id   = "cloud-run-manager"
+  description  = "Deploys new revisions and controls traffic to Cloud Run."
+  display_name = "cloud-run-manager"
+}
+
+resource "google_service_account" "website_manager" {
+  project      = var.project_id
+  account_id   = "website-manager"
+  description  = "Manages website deployments on Cloud Run."
+  display_name = "website-manager"
+}
+
+resource "google_service_account" "api_manager" {
+  project      = var.project_id
+  account_id   = "api-manager"
+  description  = "Manages API deployments on Cloud Run."
+  display_name = "api-manager"
+}
+
+resource "google_secret_manager_secret_iam_member" "secret_access_iam_client_id" {
+  project   = var.ops_project_id
+  secret_id = "client_id_secret" // this previously was contrived from ops remote state
+  role      = "roles/secretmanager.secretAccessor"
+  member    = "serviceAccount:${google_service_account.website_manager.email}"
+}
+
+resource "google_secret_manager_secret_iam_member" "secret_access_iam_client_secret" {
+  project   = var.ops_project_id
+  secret_id = "client_secret_secret" // this previously was contrived from ops remote state
+  role      = "roles/secretmanager.secretAccessor"
+  member    = "serviceAccount:${google_service_account.website_manager.email}"
+}
+
+## Cloud Run service agent access to Artifact Registry (Content API).
+resource "google_artifact_registry_repository_iam_member" "api_cloudrun_role_ar_reader" {
+  provider   = google-beta
+  project    = var.ops_project_id
+  location   = var.region
+  repository = "content-api" // this previously was contrived from ops output
+  role       = "roles/artifactregistry.reader"
+  member     = "serviceAccount:service-${data.google_project.app.number}@serverless-robot-prod.iam.gserviceaccount.com"
+  depends_on = [
+    google_project_service.emblem_app_services
+  ]
+}
+
+
+## Cloud Run service agent access to Artifact Registry (Website).
+resource "google_artifact_registry_repository_iam_member" "website_cloudrun_role_ar_reader" {
+  provider   = google-beta
+  project    = var.ops_project_id
+  location   = var.region
+  repository = "website" // this previously was contrived from ops output
+  role       = "roles/artifactregistry.reader"
+  member     = "serviceAccount:service-${data.google_project.app.number}@serverless-robot-prod.iam.gserviceaccount.com"
+  depends_on = [
+    google_project_service.emblem_app_services
+  ]
+}

--- a/terraform/modules/emblem-app/main.tf
+++ b/terraform/modules/emblem-app/main.tf
@@ -1,0 +1,80 @@
+data "google_project" "app" {
+  project_id = var.project_id
+}
+
+data "google_project" "ops" {
+  project_id = var.ops_project_id
+}
+
+# The following will check if a app engine default service account exists
+# If it already does, Terraform will not create an Appengine App
+# This is a work around for Terraform being unable to truely destroy
+# an app engine application
+# Issue: https://github.com/hashicorp/terraform-provider-google/issues/10351#issuecomment-1116555590
+data "google_app_engine_default_service_account" "default" {
+  project = var.project_id
+}
+
+resource "google_app_engine_application" "main" {
+  count         = data.google_app_engine_default_service_account.default.unique_id == null ? 1 : 0
+  project       = var.project_id
+  location_id   = replace(trimspace(var.region), "/\\d+$/", "")
+  database_type = "CLOUD_FIRESTORE"
+  depends_on = [
+    google_project_service.emblem_app_services
+  ]
+}
+
+# TODO: narrow scope of IAM permission to only necessary service accounts rather than whole project
+resource "google_project_iam_member" "cloudbuild_role_service_account_user" {
+  role    = "roles/iam.serviceAccountUser"
+  member  = "serviceAccount:${data.google_project.ops.number}@cloudbuild.gserviceaccount.com"
+  project = var.project_id
+}
+
+resource "google_project_iam_member" "cloudbuild_role_run_admin" {
+  role    = "roles/run.admin"
+  member  = "serviceAccount:${data.google_project.ops.number}@cloudbuild.gserviceaccount.com"
+  project = var.project_id
+}
+
+###
+# Pipeline Orchestration
+###
+
+resource "google_pubsub_topic" "canary" {
+  name    = "canary-${var.project_id}"
+  project = var.ops_project_id
+}
+
+resource "google_pubsub_topic" "deploy" {
+  name    = "deploy-${var.project_id}"
+  project = var.ops_project_id
+}
+
+# Define user session storage bucket.
+# Objects created in this bucket represent a new user session.
+# A user may have more than one session, representing different authenticated applications/devices.
+resource "google_storage_bucket" "sessions" {
+  name                        = "${var.project_id}-sessions"
+  project                     = var.project_id
+  uniform_bucket_level_access = true
+  force_destroy               = true
+  location                    = var.region
+  # These buckets will contain end-user data, so periodic deletion is a best practice.
+  # See: https://cloud.google.com/storage/docs/lifecycle
+  lifecycle_rule {
+    condition {
+      age = var.session_bucket_ttl_days
+    }
+    action {
+      type = "Delete"
+    }
+  }
+}
+
+resource "google_storage_bucket_iam_member" "sessions-iam" {
+  bucket = google_storage_bucket.sessions.name
+  role   = "roles/storage.objectAdmin"
+  member = "serviceAccount:${google_service_account.website_manager.email}"
+}

--- a/terraform/modules/emblem-app/services.tf
+++ b/terraform/modules/emblem-app/services.tf
@@ -1,0 +1,17 @@
+locals {
+  services = var.enable_apis ? [
+    "firestore.googleapis.com",
+    "appengine.googleapis.com",
+    "run.googleapis.com"
+
+  ] : []
+}
+
+resource "google_project_service" "emblem_app_services" {
+  for_each                   = toset(local.services)
+  project                    = var.project_id
+  service                    = each.value
+  disable_dependent_services = true
+  disable_on_destroy         = false
+}
+

--- a/terraform/modules/emblem-app/variables.tf
+++ b/terraform/modules/emblem-app/variables.tf
@@ -1,0 +1,27 @@
+variable "project_id" {
+  type        = string
+  description = "Project ID of project to deploy resources to."
+}
+
+variable "region" {
+  type        = string
+  description = "Region to deploy resources to."
+  default     = "us-central1"
+}
+
+variable "enable_apis" {
+  type        = bool
+  description = "Toggle to include required APIs."
+  default     = true
+}
+
+variable "session_bucket_ttl_days" {
+  type        = number
+  description = "Number of days before session bucket data is deleted."
+  default     = 14
+}
+
+variable "ops_project_id" {
+  type        = string
+  description = "Project ID of Emblem ops project."
+}

--- a/terraform/modules/ops/environment-build-triggers/main.tf
+++ b/terraform/modules/ops/environment-build-triggers/main.tf
@@ -1,0 +1,45 @@
+resource "google_cloudbuild_trigger" "web_deploy" {
+  for_each = var.environment_project_ids
+  project  = var.project_id
+  name     = "web-deploy-${each.value}"
+  pubsub_config {
+    # TODO: change to reference to remote state or data source
+    topic = "projects/${var.project_id}/topics/deploy-${each.value}"
+  }
+  approval_config {
+    approval_required = true
+  }
+  filter = "_IMAGE_NAME.matches('website')"
+  substitutions = {
+    _IMAGE_NAME     = "$(body.message.attributes._IMAGE_NAME)"
+    _REGION         = "$(body.message.attributes._REGION)"
+    _REVISION       = "$(body.message.attributes._REVISION)"
+    _SERVICE        = "website"
+    _TARGET_PROJECT = each.value
+    _ENV            = "${each.key}"
+  }
+  source_to_build {
+    uri       = var.github_url
+    ref       = "refs/heads/main"
+    repo_type = "GITHUB"
+  }
+
+  git_file_source {
+    path      = "ops/deploy.cloudbuild.yaml"
+    repo_type = "GITHUB"
+  }
+}
+
+# Place-holder resources
+
+resource "null_resource" "api_deploy" {
+  for_each = var.environment_project_ids
+}
+
+resource "null_resource" "web_canary" {
+  for_each = var.environment_project_ids
+}
+
+resource "null_resource" "api_canary" {
+  for_each = var.environment_project_ids
+}

--- a/terraform/modules/ops/environment-build-triggers/variables.tf
+++ b/terraform/modules/ops/environment-build-triggers/variables.tf
@@ -1,0 +1,13 @@
+variable "environment_project_ids" {
+  type = map(string)
+  description = "Map containing environment names and project IDs"
+}
+
+variable "project_id" {
+  type        = string
+  description = "Google Cloud Project to deploy triggers resources."
+}
+
+variable "github_url" {
+  type = string
+}

--- a/terraform/modules/ops/environment-build-triggers/variables.tf
+++ b/terraform/modules/ops/environment-build-triggers/variables.tf
@@ -1,5 +1,5 @@
 variable "environment_project_ids" {
-  type = map(string)
+  type        = map(string)
   description = "Map containing environment names and project IDs"
 }
 

--- a/terraform/modules/ops/main.tf
+++ b/terraform/modules/ops/main.tf
@@ -1,0 +1,148 @@
+data "google_project" "target_project" {
+  project_id = var.project_id
+}
+
+# Create this topic to emit writes to Artifact Registry as events.
+# https://cloud.google.com/artifact-registry/docs/configure-notifications#topic
+resource "google_pubsub_topic" "gcr" {
+  name     = "gcr"
+  project  = var.project_id
+  provider = google
+}
+
+resource "google_project_iam_member" "pubsub_publisher_iam_member" {
+  project  = var.project_id
+  provider = google
+  role     = "roles/pubsub.publisher"
+  member   = "serviceAccount:${data.google_project.target_project.number}@cloudbuild.gserviceaccount.com"
+
+  depends_on = [
+    google_project_service.emblem_ops_services
+  ]
+}
+
+# Container Hosting
+
+# Artifact Registry API enablement is eventually consistent
+# for brand-new GCP projects; we add a delay as a work-around.
+# For more information, see this GitHub issue:
+# https://github.com/hashicorp/terraform-provider-google/issues/11020
+resource "time_sleep" "wait_for_artifactregistry" {
+  create_duration = "20s"
+  depends_on = [
+    google_project_service.emblem_ops_beta_services
+  ]
+}
+
+resource "google_artifact_registry_repository" "website_docker" {
+  format        = "DOCKER"
+  location      = var.region
+  repository_id = "website"
+  project       = var.project_id
+  provider      = google-beta
+
+  depends_on = [
+    # Need to ensure Artifact Registry API is enabled first.
+    time_sleep.wait_for_artifactregistry
+  ]
+}
+
+resource "google_artifact_registry_repository" "api_docker" {
+  format        = "DOCKER"
+  location      = var.region
+  repository_id = "content-api"
+  project       = var.project_id
+  provider      = google-beta
+
+  depends_on = [
+    # Need to ensure Artifact Registry API is enabled first.
+    time_sleep.wait_for_artifactregistry
+  ]
+}
+
+resource "google_artifact_registry_repository" "e2e_runner_docker" {
+  format        = "DOCKER"
+  location      = var.region
+  repository_id = "e2e-runner"
+  project       = var.project_id
+  provider      = google-beta
+
+  depends_on = [
+    time_sleep.wait_for_artifactregistry
+  ]
+}
+
+###
+# Secret Manager
+###
+
+# OAuth 2.0 secrets
+# These secret resources are REQUIRED, but configuring them is OPTIONAL.
+# To avoid leaking secret data, we set their values directly with `gcloud`.
+# (Otherwise, Terraform would store secret data unencrypted in .tfstate files.)
+
+# TODO: prod and staging should use different secrets
+# See the following GitHub issue:
+#   https://github.com/GoogleCloudPlatform/emblem/issues/263
+resource "google_secret_manager_secret" "oauth_client_id" {
+  project   = var.project_id
+  secret_id = "client_id_secret"
+  replication {
+    automatic = "true"
+  }
+
+  # Adding depends_on prevents race conditions in API enablement
+  # This is a workaround for:
+  #   https://github.com/hashicorp/terraform-provider-google/issues/10682
+  depends_on = [google_project_service.emblem_ops_services]
+}
+
+resource "google_secret_manager_secret" "oauth_client_secret" {
+  project   = var.project_id
+  secret_id = "client_secret_secret"
+  replication {
+    automatic = "true"
+  }
+
+  # Adding depends_on prevents race conditions in API enablement
+  # This is a workaround for:
+  #   https://github.com/hashicorp/terraform-provider-google/issues/10682
+  depends_on = [google_project_service.emblem_ops_services]
+}
+
+###
+# Service Accounts (test users for the website)
+###
+resource "google_service_account" "website_test_user" {
+  project      = var.project_id
+  account_id   = "website-test-user"
+  display_name = "Website Test User"
+}
+
+resource "google_service_account" "website_test_approver" {
+  project      = var.project_id
+  account_id   = "website-test-approver"
+  display_name = "Website Test Approver"
+}
+
+# This topic is published to once a day via Cloud Scheduler
+# Its purpose is to trigger "nightly" builds
+resource "google_pubsub_topic" "nightly" {
+  name    = "nightly-builds"
+  project = var.project_id
+}
+
+resource "google_cloud_scheduler_job" "nightly_schedule" {
+  project     = var.project_id
+  name        = "nightly-builds"
+  description = "This job runs all nightly builds"
+  region      = var.region
+  schedule    = "*/2 * * * *"
+  pubsub_target {
+    topic_name = google_pubsub_topic.nightly.id
+    data       = base64encode("not empty")
+  }
+  depends_on = [
+    google_pubsub_topic.nightly
+  ]
+}

--- a/terraform/modules/ops/main.tf
+++ b/terraform/modules/ops/main.tf
@@ -34,6 +34,13 @@ resource "time_sleep" "wait_for_artifactregistry" {
   ]
 }
 
+resource "time_sleep" "wait_for_cloud_scheduler" {
+  create_duration = "20s"
+  depends_on = [
+    google_project_service.emblem_ops_services
+  ]
+}
+
 resource "google_artifact_registry_repository" "website_docker" {
   format        = "DOCKER"
   location      = var.region
@@ -143,6 +150,7 @@ resource "google_cloud_scheduler_job" "nightly_schedule" {
     data       = base64encode("not empty")
   }
   depends_on = [
-    google_pubsub_topic.nightly
+    google_pubsub_topic.nightly,
+    time_sleep.wait_for_artifactregistry
   ]
 }

--- a/terraform/modules/ops/main.tf
+++ b/terraform/modules/ops/main.tf
@@ -28,7 +28,7 @@ resource "google_project_iam_member" "pubsub_publisher_iam_member" {
 # For more information, see this GitHub issue:
 # https://github.com/hashicorp/terraform-provider-google/issues/11020
 resource "time_sleep" "wait_for_artifactregistry" {
-  create_duration = "20s"
+  create_duration = "40s"
   depends_on = [
     google_project_service.emblem_ops_beta_services
   ]

--- a/terraform/modules/ops/main.tf
+++ b/terraform/modules/ops/main.tf
@@ -35,7 +35,7 @@ resource "time_sleep" "wait_for_artifactregistry" {
 }
 
 resource "time_sleep" "wait_for_cloud_scheduler" {
-  create_duration = "20s"
+  create_duration = "40s"
   depends_on = [
     google_project_service.emblem_ops_services
   ]

--- a/terraform/modules/ops/services.tf
+++ b/terraform/modules/ops/services.tf
@@ -1,0 +1,29 @@
+locals {
+  services = var.enable_apis ? [
+    "cloudbuild.googleapis.com",
+    "pubsub.googleapis.com",
+    "secretmanager.googleapis.com",
+    "cloudscheduler.googleapis.com"
+  ] : []
+  # Artifact registry service only available in Google beta provider
+  beta_services = var.enable_apis ? [
+    "artifactregistry.googleapis.com"
+  ] : []
+}
+
+resource "google_project_service" "emblem_ops_services" {
+  for_each                   = toset(local.services)
+  project                    = var.project_id
+  service                    = each.value
+  disable_dependent_services = true
+  disable_on_destroy         = false
+}
+
+resource "google_project_service" "emblem_ops_beta_services" {
+  for_each                   = toset(local.beta_services)
+  provider                   = google-beta
+  project                    = var.project_id
+  service                    = each.value
+  disable_dependent_services = true
+  disable_on_destroy         = false
+}

--- a/terraform/modules/ops/triggers.tf
+++ b/terraform/modules/ops/triggers.tf
@@ -135,10 +135,11 @@ resource "google_cloudbuild_trigger" "e2e_runner_nightly_build_trigger" {
   }
 }
 
+# TODO: Cleanup/remove from ops module and move to emblem-app module
 module "environment_build_triggers" {
   source                  = "./environment-build-triggers"
   count                   = 0 # disable until fully integrated from ops/pubsub_triggers.sh
   project_id              = var.project_id
   environment_project_ids = var.environment_project_ids
-  github_url = format("https://github.com/%s/%s", var.repo_owner, var.repo_name)
+  github_url              = format("https://github.com/%s/%s", var.repo_owner, var.repo_name)
 }

--- a/terraform/modules/ops/triggers.tf
+++ b/terraform/modules/ops/triggers.tf
@@ -1,0 +1,144 @@
+resource "time_sleep" "wait_for_cloud_build_service" {
+  create_duration = "20s"
+  depends_on = [
+    google_project_service.emblem_ops_services
+  ]
+}
+
+resource "google_cloudbuild_trigger" "api_unit_tests_build_trigger" {
+  project        = var.project_id
+  count          = var.deploy_triggers ? 1 : 0
+  name           = "api-unit-tests"
+  filename       = "ops/unit-tests.cloudbuild.yaml"
+  included_files = ["content-api/**"]
+  substitutions = {
+    _DIR             = "content-api"
+    _SERVICE_ACCOUNT = format("restricted-test-identity@%s.iam.gserviceaccount.com", var.project_id)
+  }
+  github {
+    owner = var.repo_owner
+    name  = var.repo_name
+    pull_request {
+      branch          = "^main$"
+      comment_control = "COMMENTS_ENABLED_FOR_EXTERNAL_CONTRIBUTORS_ONLY"
+    }
+  }
+  depends_on = [
+    time_sleep.wait_for_cloud_build_service
+  ]
+}
+
+resource "google_cloudbuild_trigger" "api_push_to_main_build_trigger" {
+  project        = var.project_id
+  count          = var.deploy_triggers ? 1 : 0
+  name           = "api-push-to-main"
+  filename       = "ops/api-build.cloudbuild.yaml"
+  included_files = ["content-api/**"]
+  github {
+    owner = var.repo_owner
+    name  = var.repo_name
+    push {
+      branch = "^main$"
+    }
+  }
+  depends_on = [
+    time_sleep.wait_for_cloud_build_service
+  ]
+}
+
+resource "google_cloudbuild_trigger" "website_unit_tests_build_trigger" {
+  project        = var.project_id
+  count          = var.deploy_triggers ? 1 : 0
+  name           = "website-unit-tests"
+  filename       = "ops/unit-tests.cloudbuild.yaml"
+  included_files = ["website/**"]
+  substitutions = {
+    _DIR = "website"
+  }
+  github {
+    owner = var.repo_owner
+    name  = var.repo_name
+    pull_request {
+      branch          = "^main$"
+      comment_control = "COMMENTS_ENABLED_FOR_EXTERNAL_CONTRIBUTORS_ONLY"
+    }
+  }
+  depends_on = [
+    time_sleep.wait_for_cloud_build_service
+  ]
+}
+
+resource "google_cloudbuild_trigger" "web_push_to_main_build_trigger" {
+  project  = var.project_id
+  count    = var.deploy_triggers ? 1 : 0
+  name     = "web-push-to-main"
+  filename = "ops/web-build.cloudbuild.yaml"
+  included_files = [
+    "website/*",
+    "website/*/*",
+    "client-libs/python/*"
+  ]
+  github {
+    owner = var.repo_owner
+    name  = var.repo_name
+    push {
+      branch = "^main$"
+    }
+  }
+  depends_on = [
+    time_sleep.wait_for_cloud_build_service
+  ]
+}
+
+resource "google_cloudbuild_trigger" "e2e_runner_push_to_main_build_trigger" {
+  project  = var.project_id
+  count    = var.deploy_triggers ? 1 : 0
+  name     = "e2e-runner-push-to-main"
+  filename = "ops/e2e-runner-build.cloudbuild.yaml"
+  included_files = [
+    "website/e2e-test/Dockerfile",
+  ]
+  github {
+    owner = var.repo_owner
+    name  = var.repo_name
+    # NOTE: this image will ONLY be updated when a PR
+    # is merged into `main`. "Presubmit only" changes
+    # within a non-merged PR will NOT be included!
+    push {
+      branch = "^main$"
+    }
+  }
+}
+
+# TODO: Terraform will always think these resources will change due to 
+# the filename parameter, which is not required, but still populated by
+# the API.  Investigate work-around.
+
+resource "google_cloudbuild_trigger" "e2e_runner_nightly_build_trigger" {
+  project = var.project_id
+  count   = var.deploy_triggers ? 1 : 0
+  name    = "e2e-runner-nightly"
+
+  pubsub_config {
+    topic = google_pubsub_topic.nightly.id
+  }
+
+  source_to_build {
+    uri       = "https://github.com/${var.repo_owner}/${var.repo_name}"
+    ref       = "refs/heads/main"
+    repo_type = "GITHUB"
+  }
+
+  git_file_source {
+    path      = "ops/e2e-runner-build.cloudbuild.yaml"
+    repo_type = "GITHUB"
+  }
+}
+
+module "environment_build_triggers" {
+  source                  = "./environment-build-triggers"
+  count                   = 0 # disable until fully integrated from ops/pubsub_triggers.sh
+  project_id              = var.project_id
+  environment_project_ids = var.environment_project_ids
+  github_url = format("https://github.com/%s/%s", var.repo_owner, var.repo_name)
+}

--- a/terraform/modules/ops/variables.tf
+++ b/terraform/modules/ops/variables.tf
@@ -1,0 +1,39 @@
+variable "project_id" {
+  description = "Google Cloud Project to deploy module resources."
+  type        = string
+}
+
+variable "region" {
+  type        = string
+  default     = "us-central1"
+  description = "Google Cloud Region"
+}
+
+variable "repo_owner" {
+  description = "Repo Owner (GoogleCloudPlatform)"
+  type        = string
+  default     = ""
+}
+
+variable "repo_name" {
+  description = "Repo Name (emblem)"
+  type        = string
+  default     = ""
+}
+
+variable "enable_apis" {
+  type        = bool
+  description = "Toggle to include required APIs."
+  default     = true
+}
+
+variable "deploy_triggers" {
+  type        = bool
+  default     = false
+  description = "This value should only be changed to true after connecting a Github repository to your project."
+}
+
+variable "environment_project_ids" {
+  type = map(string)
+  description = "Map containing environment names and project IDs"
+}

--- a/terraform/modules/ops/variables.tf
+++ b/terraform/modules/ops/variables.tf
@@ -34,6 +34,6 @@ variable "deploy_triggers" {
 }
 
 variable "environment_project_ids" {
-  type = map(string)
+  type        = map(string)
   description = "Map containing environment names and project IDs"
 }


### PR DESCRIPTION
- experimental-setup.sh will deploy resources to the ops, staging, and prod projects and optionally run the configure_auth script. 
- Deploying triggers is disabled until we integrate them properly into the emblem-app module.