### PR TITLE
docs: create the happy user path

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -8,16 +8,23 @@ Read on if you want to explore your own Emblem instance, contribute to the proje
 
 ## Getting Started
 
-<!-- TODO: Move documentation to ./docs -->
+There are two ways to set up your own Emblem instance:
+
+* [Follow an Interactive Walkthrough in Cloud Shell](https://ssh.cloud.google.com/cloudshell/editor?cloudshell_git_repo=https://github.com/GoogleCloudPlatform/emblem&cloudshell_tutorial=docs/tutorials/setup-walkthrough.md)
+* [Follow a Tutorial in your local terminal or Cloud Shell](tutorials/setup-quickstart.md)
+
+If you prefer a minimal, manually configured instance of Emblem, you can follow
+these two walkthroughs to setup the application without Terraform:
+
+1. [Manual API Setup Walkthrough in Cloud Shell](https://ssh.cloud.google.com/cloudshell/editor?cloudshell_git_repo=https://github.com/GoogleCloudPlatform/emblem&cloudshell_tutorial=docs/tutorials/api-quickstart.md)
+1. [Manual Website Setup Walkthrough in Cloud Shell](https://ssh.cloud.google.com/cloudshell/editor?cloudshell_git_repo=https://github.com/GoogleCloudPlatform/emblem&cloudshell_tutorial=docs/tutorials/website-quickstart.md)
+
+## Learn About Emblem
+
 * [Content API](./content-api.md)
 * [Website README](./website.md)
 
-### Interactive Tutorials
-
-* [API Quickstart in Cloud Shell](https://ssh.cloud.google.com/cloudshell/editor?cloudshell_git_repo=https://github.com/GoogleCloudPlatform/emblem&cloudshell_tutorial=docs/tutorials/api-quickstart.md)
-* [Website Quickstart in Cloud Shell](https://ssh.cloud.google.com/cloudshell/editor?cloudshell_git_repo=https://github.com/GoogleCloudPlatform/emblem&cloudshell_tutorial=docs/tutorials/website-quickstart.md)
-
-## API Reference Materials
+### API Reference Materials
 
 <!-- TODO: Merge Example Requests with API Reference -->
 <!-- TODO: Merge Example Resources with seed data -->


### PR DESCRIPTION
Adjust docs/README.md so the main content we want Emblem users to prefer is presented first, ahead of "manual/contributor" instructions.