### PR TITLE
fix: use cat instead of pr

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -15,6 +15,7 @@
 
 set -eu
 
+# Should this script error, print out the line that was responsible
 _error_report() {
   echo >&2 "Exited [$?] at line $(caller):"
   cat -n $0 | tail -n+$(($1 - 3)) | head -n7 | sed "4s/^\s*/>>> /"

--- a/setup.sh
+++ b/setup.sh
@@ -17,7 +17,7 @@ set -eu
 
 _error_report() {
   echo >&2 "Exited [$?] at line $(caller):"
-  cat -tn $0 | tail -n+$(($1 - 3)) | head -n7 | sed "4s/^\s*/>>> /"
+  cat -n $0 | tail -n+$(($1 - 3)) | head -n7 | sed "4s/^\s*/>>> /"
 }
 trap '_error_report $LINENO' ERR
 

--- a/setup.sh
+++ b/setup.sh
@@ -17,7 +17,7 @@ set -eu
 
 _error_report() {
   echo >&2 "Exited [$?] at line $(caller):"
-  pr -tn $0 | tail -n+$(($1 - 3)) | head -n7 | sed "4s/^\s*/>>> /"
+  cat -tn $0 | tail -n+$(($1 - 3)) | head -n7 | sed "4s/^\s*/>>> /"
 }
 trap '_error_report $LINENO' ERR
 


### PR DESCRIPTION
`pr` is not supported in Alpine linux, but `cat` is

(Extracted from #487)