### PR TITLE
fix: allow automatic content API package installs

### DIFF
--- a/ops/e2e-deployer/Dockerfile
+++ b/ops/e2e-deployer/Dockerfile
@@ -18,5 +18,11 @@
 
 FROM google/cloud-sdk:alpine
 
+# Install pip
+RUN apk add py3-pip
+
+# Install packages used by Content API
+RUN pip install content-api/requirements.txt
+
 # Install Terraform
 RUN apk add terraform --repository=https://dl-cdn.alpinelinux.org/alpine/edge/community

--- a/ops/e2e-deployer/Dockerfile
+++ b/ops/e2e-deployer/Dockerfile
@@ -25,5 +25,4 @@ RUN apk add py3-pip
 RUN apk add terraform --repository=https://dl-cdn.alpinelinux.org/alpine/edge/community
 
 # Install packages used by Content API
-COPY ../../content-api/requirements.txt requirements.txt
-RUN pip install requirements.txt
+RUN pip install content-api-requirements.txt

--- a/ops/e2e-deployer/Dockerfile
+++ b/ops/e2e-deployer/Dockerfile
@@ -21,8 +21,9 @@ FROM google/cloud-sdk:alpine
 # Install pip
 RUN apk add py3-pip
 
-# Install packages used by Content API
-RUN pip install content-api/requirements.txt
-
 # Install Terraform
 RUN apk add terraform --repository=https://dl-cdn.alpinelinux.org/alpine/edge/community
+
+# Install packages used by Content API
+COPY ../../content-api/requirements.txt requirements.txt
+RUN pip install requirements.txt

--- a/ops/e2e-deployer/Dockerfile
+++ b/ops/e2e-deployer/Dockerfile
@@ -25,4 +25,4 @@ RUN apk add py3-pip
 RUN apk add terraform --repository=https://dl-cdn.alpinelinux.org/alpine/edge/community
 
 # Install packages used by Content API
-RUN pip install content-api-requirements.txt
+RUN pip install -r content-api-requirements.txt

--- a/ops/e2e-deployer/content-api-requirements.txt
+++ b/ops/e2e-deployer/content-api-requirements.txt
@@ -1,0 +1,1 @@
+../../content-api/requirements.txt


### PR DESCRIPTION
Question for @grayside or @engelke:

> Is this better built into a Docker image, or installed via `setup.sh`?

(Docker images are better performance-wise, but will have outdated dependencies until they're rebuilt [either nightly or post-`main`-merge]. **Note** that Docker doesn't like files outside its parent directory [not even symlinks!], so we'll have to somehow fetch the right contents to use.)