### PR TITLE
fix: restore staging trigger config and add env toggles

### DIFF
--- a/ops/canary.cloudbuild.yaml
+++ b/ops/canary.cloudbuild.yaml
@@ -61,9 +61,9 @@ steps:
         if [ ${_TRAFFIC} -lt 100 ]
         then gcloud pubsub topics publish canary-${_TARGET_PROJECT} \
         --message="Increase ${_SERVICE}-${_REVISION} traffic to $((${_TRAFFIC}+5))" \
-        --attribute=_IMAGE_NAME=${_IMAGE_NAME},_ENV=${_ENV},_SERVICE=${_SERVICE},_REVISION=${_REVISION},_REGION=${_REGION},_TRAFFIC=$((${_TRAFFIC}+5))
+        --attribute=_IMAGE_NAME=${_IMAGE_NAME},_ENV=${_ENV},_SERVICE=${_SERVICE},_REVISION=${_REVISION},_TRAFFIC=$((${_TRAFFIC}+5))
         else
         gcloud pubsub topics publish deploy-completed-${_ENV} \
         --message="Deployed ${_SERVICE}-${_REVISION} [${_ENV}] to ${_TARGET_PROJECT}" \
-        --attribute=_IMAGE_NAME=${_IMAGE_NAME},_ENV=${_ENV},_SERVICE=${_SERVICE},_REVISION=${_REVISION},_REGION=${_REGION}
+        --attribute=_IMAGE_NAME=${_IMAGE_NAME},_ENV=${_ENV},_SERVICE=${_SERVICE},_REVISION=${_REVISION}
         fi

--- a/ops/deploy.cloudbuild.yaml
+++ b/ops/deploy.cloudbuild.yaml
@@ -36,7 +36,7 @@ steps:
       - publish
       - canary-${_ENV}
       - --message="Ready for ${_SERVICE}-${_REVISION} rollout"
-      - --attribute=_TARGET_PROJECT=${_TARGET_PROJECT},_IMAGE_NAME=${_IMAGE_NAME},_ENV=${_ENV},_SERVICE=${_SERVICE},_REVISION=${_REVISION},_REGION=${_REGION},_TRAFFIC=5
+      - --attribute=_TARGET_PROJECT=${_TARGET_PROJECT},_IMAGE_NAME=${_IMAGE_NAME},_ENV=${_ENV},_SERVICE=${_SERVICE},_REVISION=${_REVISION},_TRAFFIC=5
 
 options:
     substitution_option: 'ALLOW_LOOSE'

--- a/terraform/environments/prod/main.tf
+++ b/terraform/environments/prod/main.tf
@@ -16,4 +16,6 @@ module "emblem_prod" {
   repo_owner              = var.repo_owner
   repo_name               = var.repo_name
   deploy_trigger_topic_id = data.google_pubsub_topic.deploy_trigger.id
+  gcr_pubsub_format       = false
+  require_deploy_approval = true
 }

--- a/terraform/environments/staging/main.tf
+++ b/terraform/environments/staging/main.tf
@@ -16,4 +16,6 @@ module "emblem_staging" {
   repo_owner              = var.repo_owner
   repo_name               = var.repo_name
   deploy_trigger_topic_id = data.google_pubsub_topic.deploy_trigger.id
+  gcr_pubsub_format       = true
+  require_deploy_approval = false
 }

--- a/terraform/modules/emblem-app/variables.tf
+++ b/terraform/modules/emblem-app/variables.tf
@@ -43,6 +43,18 @@ variable "deploy_trigger_topic_id" {
   description = "Pub/Sub Topic ID that triggers Cloud Build deployment."
 }
 
+variable "gcr_pubsub_format" {
+  type        = bool
+  default     = true
+  description = "True if Cloud Build deploy triggers should expect GCR message format."
+}
+
+variable "require_deploy_approval" {
+  type        = bool
+  default     = false
+  description = "The application services require manual approval to be deployed."
+}
+
 variable "deploy_session_bucket" {
   type        = bool
   default     = true


### PR DESCRIPTION
Follow-up to #509, part of fixing #497 and #498.

* Inherit Cloud Run region from environment configuration instead of Pub/Sub message
* Staging uses gcr Pub/Sub format, not custom Emblem format
* Add gcr_pubsub_format and require_deploy_approval feature toggles in terraform to replace environment special casing

Documenting pubsub message expectations will be done in follow-up.