### PR TITLE
fix: PR trigger in autolabeler

### DIFF
--- a/.github/workflows/auto-label.yml
+++ b/.github/workflows/auto-label.yml
@@ -15,7 +15,7 @@
 name: Auto Label
 on:
   pull_request_target:
-    types: [ opened, reopened, synchronized, edited ]
+    types: [ opened, reopened, synchronize, edited ]
 
 # Add labels to Pull Requests
 permissions:


### PR DESCRIPTION
There's no such event as `synchronized`, so I updated the Github Action yml according the [official docs](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request_target=)

```diff
- synchronized
+ synchronize
```