### PR TITLE
fix: add deploy_session_bucket var to prod

### DIFF
--- a/terraform/environments/prod/variables.tf
+++ b/terraform/environments/prod/variables.tf
@@ -20,6 +20,12 @@ variable "enable_apis" {
   default     = true
 }
 
+variable "deploy_session_bucket" {
+  type        = bool
+  default     = true
+  description = "Whether or not to deploy a [fresh] bucket for storing session data"
+}
+
 variable "session_bucket_ttl_days" {
   type        = number
   description = "Number of days before session bucket data is deleted."


### PR DESCRIPTION
While we don't plan to do e2e testing into the prod environment, this creates a consistent environment configuration between stage & prod, and fixes an error introduced by copying main.tf code between environments.