### PR TITLE
fix: nightly cron running every 2 minutes

### DIFF
--- a/terraform/modules/ops/main.tf
+++ b/terraform/modules/ops/main.tf
@@ -121,7 +121,7 @@ resource "google_cloud_scheduler_job" "nightly_schedule" {
   name        = "nightly"
   description = "This job runs nightly operations."
   region      = var.region
-  schedule    = "*/2 * * * *"
+  schedule    = "0 2 * * *"
   pubsub_target {
     topic_name = google_pubsub_topic.nightly.id
     data       = base64encode("not empty")


### PR DESCRIPTION
Current cron configuration runs every 2 minutes. Switch to running nightly at 2am.

https://crontab.guru/ is a helpful tool to troubleshooting scheduler config.