### PR TITLE
fix: stop deploy updates removing service configuration

### DIFF
--- a/ops/deploy.cloudbuild.yaml
+++ b/ops/deploy.cloudbuild.yaml
@@ -25,7 +25,7 @@ steps:
       - --project=${_TARGET_PROJECT}
       - --allow-unauthenticated
       - --no-traffic
-      - --set-env-vars=${_ENV_VARS}
+      - --update-env-vars=${_ENV_VARS}
       - --tag=latest
 
   # Send message to pub/sub to start canary rollout process


### PR DESCRIPTION
`--set-env-vars` in the Cloud Build configuration is removing environment variables we configured via setup.sh and scripts/configure_auth.sh.

By switching to `--update-env-vars`, previously set configuration will be retained.