### PR TITLE
feat:use remote terraform state in setup

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -71,6 +71,7 @@ if [[ -z "$SKIP_TERRAFORM" ]]; then
 
     STATE_GCS_BUCKET_NAME="$OPS_PROJECT-tf-states"
     gsutil mb -p $OPS_PROJECT -l $REGION gs://${STATE_GCS_BUCKET_NAME}
+    gsutil versioning set on gs://${STATE_GCS_BUCKET_NAME}
     
     # Ops Project
     OPS_ENVIRONMENT_DIR=terraform/environments/ops

--- a/setup.sh
+++ b/setup.sh
@@ -69,12 +69,15 @@ if [[ -z "$SKIP_TERRAFORM" ]]; then
     echo "$(tput bold)Setting up your Cloud resources with Terraform...$(tput sgr0)"
     echo
 
+    STATE_GCS_BUCKET_NAME="$OPS_PROJECT-tf-states"
+    gsutil mb -p $OPS_PROJECT -l $REGION gs://${STATE_GCS_BUCKET_NAME}
+    
     # Ops Project
     OPS_ENVIRONMENT_DIR=terraform/environments/ops
     cat > "${OPS_ENVIRONMENT_DIR}/terraform.tfvars" <<EOF
 project_id = "${OPS_PROJECT}"
 EOF
-    terraform -chdir=${OPS_ENVIRONMENT_DIR} init
+    terraform -chdir=${OPS_ENVIRONMENT_DIR} init -backend-config="bucket=${STATE_GCS_BUCKET_NAME}" -backend-config="prefix=ops"
     terraform -chdir=${OPS_ENVIRONMENT_DIR} apply --auto-approve
 
     # Staging Project
@@ -83,7 +86,7 @@ EOF
 project_id = "${STAGE_PROJECT}"
 ops_project_id = "${OPS_PROJECT}"
 EOF
-    terraform -chdir=${STAGE_ENVIRONMENT_DIR} init
+    terraform -chdir=${STAGE_ENVIRONMENT_DIR} init -backend-config="bucket=${STATE_GCS_BUCKET_NAME}" -backend-config="prefix=stage"
     terraform -chdir=${STAGE_ENVIRONMENT_DIR} apply --auto-approve
 
     # Prod Project
@@ -94,7 +97,7 @@ EOF
 project_id = "${PROD_PROJECT}"
 ops_project_id = "${OPS_PROJECT}"
 EOF
-        terraform -chdir=${PROD_ENVIRONMENT_DIR} init
+        terraform -chdir=${PROD_ENVIRONMENT_DIR} init -backend-config="bucket=${STATE_GCS_BUCKET_NAME}" -backend-config="prefix=prod"
         terraform -chdir=${PROD_ENVIRONMENT_DIR} apply --auto-approve
     fi
 

--- a/terraform/environments/ops/backend.tf
+++ b/terraform/environments/ops/backend.tf
@@ -1,0 +1,4 @@
+terraform {
+  backend "gcs" {
+  }
+}

--- a/terraform/environments/prod/backend.tf
+++ b/terraform/environments/prod/backend.tf
@@ -1,0 +1,4 @@
+terraform {
+  backend "gcs" {
+  }
+}

--- a/terraform/environments/staging/backend.tf
+++ b/terraform/environments/staging/backend.tf
@@ -1,0 +1,4 @@
+terraform {
+  backend "gcs" {
+  }
+}


### PR DESCRIPTION
fixes #97 

This PR:
- Adds terraform `backend` block to each directory in `terraform/environments/`
- Adds `gsutil mb` command to setup - will create gcs bucket in ops project named `${OPS_PROJECT}-tf-states`
- Updates `terraform init` commands to use the remote backend via `-backend-config` flags
 
GCS bucket file structure:
- gs://${OPS_PROJECT}-tf-states
   - /ops
       - default.tfstate
   - /stage
       - default.tfstate
   - /prod
       - default.tfstate