### PR TITLE
fix: restore _BODY substitution to Pub/Sub triggered builds

### DIFF
--- a/ops/canary.cloudbuild.yaml
+++ b/ops/canary.cloudbuild.yaml
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 steps:
-  # Prints entire body of pub/sub message for debugging
+  # Print the full Pub/Sub message for debugging.
   - name: gcr.io/cloud-builders/gcloud
     entrypoint: /bin/bash
     args:

--- a/ops/deploy.cloudbuild.yaml
+++ b/ops/deploy.cloudbuild.yaml
@@ -13,6 +13,14 @@
 # limitations under the License.
 
 steps:
+  # Print the full Pub/Sub message for debugging.
+  - name: gcr.io/cloud-builders/gcloud
+    entrypoint: /bin/bash
+    args:
+      - '-c'
+      - |
+        echo ${_BODY}
+
   # Cloud Run Deploy
   - name: gcr.io/cloud-builders/gcloud
     args:
@@ -25,7 +33,6 @@ steps:
       - --project=${_TARGET_PROJECT}
       - --allow-unauthenticated
       - --no-traffic
-      - --update-env-vars=${_ENV_VARS}
       - --tag=latest
 
   # Send message to pub/sub to start canary rollout process

--- a/terraform/modules/emblem-app/deploy.tf
+++ b/terraform/modules/emblem-app/deploy.tf
@@ -67,12 +67,13 @@ resource "google_cloudbuild_trigger" "web_deploy" {
   }
   filter = "_IMAGE_NAME.matches('website')"
   substitutions = {
+    _BODY           = "$(body)"
+    _ENV            = var.environment
     _IMAGE_NAME     = var.gcr_pubsub_format ? "$(body.message.data.tag)" : "$(body.message.attributes._IMAGE_NAME)"
     _REGION         = var.region
     _REVISION       = var.gcr_pubsub_format ? "$(body.message.messageId)" : "$(body.message.attributes._REVISION)"
     _SERVICE        = "website"
     _TARGET_PROJECT = var.project_id
-    _ENV            = var.environment
   }
   source_to_build {
     uri       = format("https://github.com/%s/%s", var.repo_owner, var.repo_name)
@@ -97,12 +98,13 @@ resource "google_cloudbuild_trigger" "api_deploy" {
   }
   filter = "_IMAGE_NAME.matches('content-api')"
   substitutions = {
+    _BODY           = "$(body)"
+    _ENV            = var.environment
     _IMAGE_NAME     = var.gcr_pubsub_format ? "$(body.message.data.tag)" : "$(body.message.attributes._IMAGE_NAME)"
     _REGION         = var.region
     _REVISION       = var.gcr_pubsub_format ? "$(body.message.messageId)" : "$(body.message.attributes._REVISION)"
     _SERVICE        = "content-api"
     _TARGET_PROJECT = var.project_id
-    _ENV            = var.environment
   }
   source_to_build {
     uri       = format("https://github.com/%s/%s", var.repo_owner, var.repo_name)
@@ -129,13 +131,14 @@ resource "google_cloudbuild_trigger" "web_canary" {
   }
   filter = format("_SERVICE.matches('%s')", "website")
   substitutions = {
+    _BODY           = "$(body)"
+    _ENV            = var.environment
     _IMAGE_NAME     = "$(body.message.attributes._IMAGE_NAME)"
     _REGION         = var.region
     _REVISION       = "$(body.message.attributes._REVISION)"
-    _TRAFFIC        = "$(body.message.attributes._TRAFFIC)"
     _SERVICE        = "website"
     _TARGET_PROJECT = var.project_id
-    _ENV            = var.environment
+    _TRAFFIC        = "$(body.message.attributes._TRAFFIC)"
   }
   source_to_build {
     uri       = format("https://github.com/%s/%s", var.repo_owner, var.repo_name)
@@ -160,13 +163,14 @@ resource "google_cloudbuild_trigger" "api_canary" {
   }
   filter = format("_SERVICE.matches('%s')", "content-api")
   substitutions = {
+    _BODY           = "$(body)"
+    _ENV            = var.environment
     _IMAGE_NAME     = "$(body.message.attributes._IMAGE_NAME)"
     _REGION         = var.region
     _REVISION       = "$(body.message.attributes._REVISION)"
-    _TRAFFIC        = "$(body.message.attributes._TRAFFIC)"
     _SERVICE        = "content-api"
     _TARGET_PROJECT = var.project_id
-    _ENV            = var.environment
+    _TRAFFIC        = "$(body.message.attributes._TRAFFIC)"
   }
   source_to_build {
     uri       = format("https://github.com/%s/%s", var.repo_owner, var.repo_name)


### PR DESCRIPTION
This was mostly removed over the course of various refactoring, but recent troubleshooting needs show it's value.

* Use the entire Pub/Sub body as a substitution
* Echo this object to the build log as the first step (before anything else can go wrong)
* Re-order substitutions in terraform config to alphabetical order to match display order in console.