### PR TITLE
fix: canary deploys by intervals of 20% instead of 5%

### DIFF
--- a/ops/canary.cloudbuild.yaml
+++ b/ops/canary.cloudbuild.yaml
@@ -60,8 +60,8 @@ steps:
       - |
         if [ ${_TRAFFIC} -lt 100 ]
         then gcloud pubsub topics publish canary-${_ENV} \
-        --message="Increase ${_SERVICE}-${_REVISION} traffic to $((${_TRAFFIC}+5))" \
-        --attribute=_IMAGE_NAME=${_IMAGE_NAME},_ENV=${_ENV},_SERVICE=${_SERVICE},_REVISION=${_REVISION},_TRAFFIC=$((${_TRAFFIC}+5))
+        --message="Increase ${_SERVICE}-${_REVISION} traffic to $((${_TRAFFIC}+20))" \
+        --attribute=_IMAGE_NAME=${_IMAGE_NAME},_ENV=${_ENV},_SERVICE=${_SERVICE},_REVISION=${_REVISION},_TRAFFIC=$((${_TRAFFIC}+20))
         else
         gcloud pubsub topics publish deploy-completed-${_ENV} \
         --message="Deployed ${_SERVICE}-${_REVISION} [${_ENV}] to ${_TARGET_PROJECT}" \

--- a/ops/deploy.cloudbuild.yaml
+++ b/ops/deploy.cloudbuild.yaml
@@ -36,7 +36,7 @@ steps:
       - publish
       - canary-${_ENV}
       - --message="Ready for ${_SERVICE}-${_REVISION} rollout"
-      - --attribute=_TARGET_PROJECT=${_TARGET_PROJECT},_IMAGE_NAME=${_IMAGE_NAME},_ENV=${_ENV},_SERVICE=${_SERVICE},_REVISION=${_REVISION},_TRAFFIC=5
+      - --attribute=_TARGET_PROJECT=${_TARGET_PROJECT},_IMAGE_NAME=${_IMAGE_NAME},_ENV=${_ENV},_SERVICE=${_SERVICE},_REVISION=${_REVISION},_TRAFFIC=20
 
 options:
     substitution_option: 'ALLOW_LOOSE'


### PR DESCRIPTION
The current canary strategy is "increment by 5%". A more ideal strategy would follow a more geometric or exponential curve, but to simplify the behavior for now, increasing the interval to 20 so we have 5 canary builds instead of 20 per rollout.