### PR TITLE
fix: canary build triggers filter on matching service

### DIFF
--- a/terraform/modules/emblem-app/deploy.tf
+++ b/terraform/modules/emblem-app/deploy.tf
@@ -133,7 +133,7 @@ resource "google_cloudbuild_trigger" "web_canary" {
     _REGION         = var.region
     _REVISION       = "$(body.message.attributes._REVISION)"
     _TRAFFIC        = "$(body.message.attributes._TRAFFIC)"
-    _SERVICE        = "website"
+    _SERVICE        = "$(body.message.attributes._SERVICE)"
     _TARGET_PROJECT = var.project_id
     _ENV            = var.environment
   }
@@ -164,7 +164,7 @@ resource "google_cloudbuild_trigger" "api_canary" {
     _REGION         = var.region
     _REVISION       = "$(body.message.attributes._REVISION)"
     _TRAFFIC        = "$(body.message.attributes._TRAFFIC)"
-    _SERVICE        = "content-api"
+    _SERVICE        = "$(body.message.attributes._SERVICE)"
     _TARGET_PROJECT = var.project_id
     _ENV            = var.environment
   }


### PR DESCRIPTION
The canary Cloud Builds have Pub/Sub triggers. These triggers filter on the build substitution `_SERVICE` matching the service associated with the trigger. However, at some point I simplified the trigger definition to hard-code the `_SERVICE` substitution to the known service name, instead of the Pub/Sub message.

As a result, the canary build triggers were always matching the filter whenever any Pub/Sub message reached them.

This change reverts that mistake, ensuring that a canary trigger only kicks off if the canary topic for that environment is messaging for the particular service.