### PR TITLE
fix(issue-607): add link back to original campaign

### DIFF
--- a/website/static/site.css
+++ b/website/static/site.css
@@ -221,6 +221,10 @@ img.emblem-avatar {
 }
 
 /* Donate button */
+.emblem-donation-wrapper {
+  margin: 10px auto;
+}
+
 .emblem-campaign-details .mdc-button {
   margin-top: 1em;
   float: right;

--- a/website/templates/donations/view-donation.html
+++ b/website/templates/donations/view-donation.html
@@ -20,7 +20,7 @@
 
 {% block content %}
 <div class="mdc-layout-grid">
-  <a href="/">Back to campaign list</a>
+  <a href="/viewCampaign?campaign_id={{ campaign.id }}">Back to campaign</a>
   <div class="mdc-layout-grid__inner">
     <div class="emblem-campaign-details mdc-layout-grid__cell mdc-layout-grid__cell--span-12">
       <ul class="mdc-list">
@@ -48,6 +48,9 @@
           <span class="mdc-list-item__meta">{{ donation.time_created }}</span>
         </li>
       </ul>
+  
+      <!-- Campaign List button -->
+      <a href="/" class="mdc-button mdc-button--outlined">Back to campaign list</a>
       <!-- Donate button -->
       <a href="/donate?campaign_id={{ campaign.id }}" class="mdc-button mdc-button--raised">
         <span class="mdc-button__ripple"></span>

--- a/website/templates/donations/view-donation.html
+++ b/website/templates/donations/view-donation.html
@@ -20,8 +20,9 @@
 
 {% block content %}
 <div class="mdc-layout-grid">
-  <a href="/viewCampaign?campaign_id={{ campaign.id }}">Back to campaign</a>
-  <div class="mdc-layout-grid__inner">
+  <!-- Campaign button -->
+  <a href="/viewCampaign?campaign_id={{ campaign.id }}" class="mdc-button mdc-button--outlined">Back to campaign</a>
+  <div class="emblem-donation-wrapper mdc-layout-grid__inner">
     <div class="emblem-campaign-details mdc-layout-grid__cell mdc-layout-grid__cell--span-12">
       <ul class="mdc-list">
         <li role="separator" class="mdc-list-divider"></li>
@@ -49,8 +50,6 @@
         </li>
       </ul>
   
-      <!-- Campaign List button -->
-      <a href="/" class="mdc-button mdc-button--outlined">Back to campaign list</a>
       <!-- Donate button -->
       <a href="/donate?campaign_id={{ campaign.id }}" class="mdc-button mdc-button--raised">
         <span class="mdc-button__ripple"></span>


### PR DESCRIPTION
Issue: #607 

**Steps to re-create:**

Requirements, you should have a deployed `content-api` container and a fully seeded firestore. You may leverage my project if you'd like, just ping.

1) In personal GCP, redeploy `content-api` container 
2) Set env variable `EMBLEM_API_URL` to that `content-api` container url
```
export EMBLEM_API_URL=https://content-api-c55u7v66jq-uc.a.run.app/
```
3) Open `website/` and start running the flask app
```
cd website/
pip3 install -r requirements.txt
flask run
```
4) Open browser @ `http://localhost:5000/viewDonation?donation_id=00f12b60ba35489f902f`

You should see the following. Clicking `Back to Campaign` will redirect to parent campaign page.

<img width="919" alt="Screen Shot 2022-08-15 at 10 44 58 AM" src="https://user-images.githubusercontent.com/1331216/184687828-a2eb770b-b03a-475a-b701-67657fe875b3.png">

<img width="920" alt="Screen Shot 2022-08-15 at 10 46 04 AM" src="https://user-images.githubusercontent.com/1331216/184687869-19a8f2b9-7ff2-4ac4-8a33-fd5efeea1478.png">


