### PR TITLE
fix: only allow numbers in donation amount

### DIFF
--- a/website/templates/donations/new-donation.html
+++ b/website/templates/donations/new-donation.html
@@ -52,7 +52,7 @@
         <label class="emblem-donation-input mdc-text-field mdc-text-field--filled mdc-text-field--label-floating">
           <span class="mdc-text-field__ripple"></span>
           <span class="mdc-floating-label" id="amount-label">Amount (in USD):</span>
-          <input required type="text" id="amount" name="amount" class="mdc-text-field__input" aria-labelledby="amount">
+          <input required type="number" id="amount" name="amount" class="mdc-text-field__input" aria-labelledby="amount">
           <span class="mdc-line-ripple"></span>
         </label>
         


### PR DESCRIPTION
This can't be trusted by the API, but it might be helpful for end-users.