### PR TITLE
fix: pin Playwright Dockerfile version

### DIFF
--- a/ops/e2e-runner/Dockerfile
+++ b/ops/e2e-runner/Dockerfile
@@ -16,7 +16,7 @@
 # This Dockerfile is used to run the website for Playwright tests #
 ###################################################################
 
-FROM mcr.microsoft.com/playwright:focal
+FROM mcr.microsoft.com/playwright:v1.22.2-focal-amd64
 RUN apt-get update && \
     apt-get install -y software-properties-common && \
     add-apt-repository ppa:deadsnakes/ppa -y && \


### PR DESCRIPTION
Along with #622, this should fix the failing `web-system-tests` CI check.

Backstory:
> Playwright's Docker image was updated, but the corresponding NPM dependency was not.
>
> Even if the NPM dependency **had** been updated, it doesn't seem in-sync with the `latest`-tagged Docker image.