### PR TITLE
fix(issue-608): hide create campaign link

### DIFF
--- a/website/templates/auth/logout.html
+++ b/website/templates/auth/logout.html
@@ -19,6 +19,12 @@
 {% block title %}Log Out{% endblock %}
 
 {% block content %}
-  <h1>You have been logged out.</h1>
-  <p><a href="/">Return to home page</a></p>
+<div class="mdc-layout-grid">
+  <div class="mdc-layout-grid__inner">
+    <div class="mdc-layout-grid__cell mdc-layout-grid__cell--span-12">
+      <h1>You have been logged out.</h1>
+      <a href="/" class="mdc-button mdc-button--outlined">Return to home page</a>
+    </div>
+  </div>
+</div>
 {% endblock %}

--- a/website/templates/home.html
+++ b/website/templates/home.html
@@ -24,7 +24,7 @@
     <div class="mdc-layout-grid__inner">
         <div class="mdc-layout-grid__cell mdc-layout-grid__cell--span-12">
             <h2>Discover a giving campaign!</h2>
-            {% if current_user != None %}
+            {% if current_user %}
             <!-- Create Campaign button -->
             <a href="/createCampaign" class="mdc-button mdc-button--raised">
                 <span class="mdc-button__ripple"></span>

--- a/website/templates/home.html
+++ b/website/templates/home.html
@@ -24,11 +24,13 @@
     <div class="mdc-layout-grid__inner">
         <div class="mdc-layout-grid__cell mdc-layout-grid__cell--span-12">
             <h2>Discover a giving campaign!</h2>
+            {% if current_user != None %}
             <!-- Create Campaign button -->
             <a href="/createCampaign" class="mdc-button mdc-button--raised">
                 <span class="mdc-button__ripple"></span>
                 <span class="mdc-button__label">Create new campaign</span>
             </a>
+            {% endif %}
         </div>
     </div>
 </div>

--- a/website/views/campaigns.py
+++ b/website/views/campaigns.py
@@ -29,13 +29,18 @@ campaigns_bp = Blueprint("campaigns", __name__, template_folder="templates")
 
 @campaigns_bp.route("/")
 def list_campaigns():
+    current_user = None
+
+    if g.session_data is not None:
+        current_user = g.session_data.get("email")
+
     try:
         campaigns = g.api.campaigns_get()
     except Exception as e:
-        log(f"Exception when listing campaigns: {e}", severity="ERROR")
+        log(f"Exception when on listing campaigns view: {e}", severity="ERROR")
         campaigns = []
 
-    return render_template("home.html", campaigns=campaigns)
+    return render_template("home.html", campaigns=campaigns, current_user=current_user)
 
 
 @campaigns_bp.route("/createCampaign", methods=["GET"])

--- a/website/views/campaigns.py
+++ b/website/views/campaigns.py
@@ -31,7 +31,7 @@ campaigns_bp = Blueprint("campaigns", __name__, template_folder="templates")
 def list_campaigns():
     current_user = None
 
-    if g.session_data is not None:
+    if g.session_data:
         current_user = g.session_data.get("email")
 
     try:


### PR DESCRIPTION
Resolves issue: #608 

**Fix:** Instead of disabling button, I've decided to hide it. If this is never to be enabled for someone 
just perusing incognito, it should only be displayed for logged in users.

**Steps to recreate:**

1) Check branch out and rebuild `website/` image and redeploy on your personal GCP
2) Without logging in, you should no longer see the button displayed on the homepage
3) Go through login and when you've landed back on the homepage you should see the button displayed again

Note: Happy to let you leverage my GCP project if necessary to review this. I will just need to add you as an approver.

<img width="857" alt="Screen Shot 2022-08-16 at 6 54 44 PM" src="https://user-images.githubusercontent.com/1331216/185018156-eb56c124-f292-4236-b03c-73ca91305ded.png">

<img width="861" alt="Screen Shot 2022-08-16 at 6 55 00 PM" src="https://user-images.githubusercontent.com/1331216/185018172-6f92455b-d184-4be4-8e75-29d9a1a1df15.png">
