### PR TITLE
fix: add cors to content-api, force trigger api test failure

### DIFF
--- a/content-api/main.py
+++ b/content-api/main.py
@@ -14,7 +14,6 @@
 
 from os import set_inheritable
 from flask import Flask, g, request
-from flask_cors import CORS
 
 from google.auth.transport import requests as reqs
 from google.oauth2 import id_token
@@ -30,7 +29,6 @@ resource = [
     "donors",
 ]
 app = Flask(__name__)
-cors = CORS(app)
 
 
 # Check authentication and remember result in global request context

--- a/content-api/main.py
+++ b/content-api/main.py
@@ -14,6 +14,7 @@
 
 from os import set_inheritable
 from flask import Flask, g, request
+from flask_cors import CORS
 
 from google.auth.transport import requests as reqs
 from google.oauth2 import id_token
@@ -28,8 +29,8 @@ resource = [
     "donations",
     "donors",
 ]
-
 app = Flask(__name__)
+cors = CORS(app)
 
 
 # Check authentication and remember result in global request context

--- a/content-api/main_nonapprover_test.py
+++ b/content-api/main_nonapprover_test.py
@@ -273,8 +273,11 @@ def test_insert_with_authentication(client):
 
     # Donors should work for donor == test user
     r = client.post(f"/donors", headers=headers, json=TEST_DONORS[EMAIL])
-    print('------------')
+    print('-----debugging-------')
     print(TEST_DONORS[EMAIL])
+    print(EMAIL)
+    print(headers)
+    print(id_token)
 
     assert r.status_code == 201
     assert r.headers.get("Content-Type") == "application/json"

--- a/content-api/main_nonapprover_test.py
+++ b/content-api/main_nonapprover_test.py
@@ -273,6 +273,9 @@ def test_insert_with_authentication(client):
 
     # Donors should work for donor == test user
     r = client.post(f"/donors", headers=headers, json=TEST_DONORS[EMAIL])
+    print('------------')
+    print(TEST_DONORS[EMAIL])
+
     assert r.status_code == 201
     assert r.headers.get("Content-Type") == "application/json"
     payload = json.loads(r.data)

--- a/content-api/main_nonapprover_test.py
+++ b/content-api/main_nonapprover_test.py
@@ -46,6 +46,8 @@ token = os.environ.get("ID_TOKEN")
 
 
 if token is not None:
+    print('------ token found -----')
+    print('------ token -----')
     headers = {"Authorization": f"Bearer {token}"}
 
     info = None

--- a/content-api/main_nonapprover_test.py
+++ b/content-api/main_nonapprover_test.py
@@ -281,10 +281,13 @@ def test_insert_with_authentication(client):
     print('-----debugging-------')
     print(TEST_DONORS[EMAIL])
     print(EMAIL)
+    print('----- headers ------')
     print(headers)
+    print('----- id_token ------')
     print(id_token)
     print('----- token ------')
     print(token)
+    print(os.environ.get("ID_TOKEN"))
 
     assert r.status_code == 201
     assert r.headers.get("Content-Type") == "application/json"

--- a/content-api/main_nonapprover_test.py
+++ b/content-api/main_nonapprover_test.py
@@ -43,6 +43,10 @@ TEST_CAUSE = None
 
 # Set auth headers from the ID_TOKEN if possible
 token = os.environ.get("ID_TOKEN")
+
+print('----- token ------')
+print(token)
+
 if token is not None:
     headers = {"Authorization": f"Bearer {token}"}
 
@@ -63,6 +67,7 @@ if token is not None:
     if info is not None and "email" in info:
         EMAIL = info["email"]
 else:
+    print('------ no token found -----')
     headers = {}
 
 

--- a/content-api/main_nonapprover_test.py
+++ b/content-api/main_nonapprover_test.py
@@ -44,8 +44,6 @@ TEST_CAUSE = None
 # Set auth headers from the ID_TOKEN if possible
 token = os.environ.get("ID_TOKEN")
 
-print('----- token ------')
-print(token)
 
 if token is not None:
     headers = {"Authorization": f"Bearer {token}"}
@@ -283,6 +281,8 @@ def test_insert_with_authentication(client):
     print(EMAIL)
     print(headers)
     print(id_token)
+    print('----- token ------')
+    print(token)
 
     assert r.status_code == 201
     assert r.headers.get("Content-Type") == "application/json"

--- a/content-api/requirements.txt
+++ b/content-api/requirements.txt
@@ -1,5 +1,4 @@
 flask==2.1.2
-flask_cors==3.0.10
 google-cloud-firestore==2.5.2
 gunicorn==20.1.0
 google.auth==2.7.0

--- a/content-api/requirements.txt
+++ b/content-api/requirements.txt
@@ -1,4 +1,5 @@
 flask==2.1.2
+flask_cors==3.0.10
 google-cloud-firestore==2.5.2
 gunicorn==20.1.0
 google.auth==2.7.0


### PR DESCRIPTION
Related issue: #610 
DON'T MERGE - debugging api-test failure

Context: Looks like its a general permissions failure when anything modifies `content-api` tests. 

```
main_nonapprover_test.py:315: AssertionError
=========================== short test summary info ============================
FAILED main_approver_test.py::test_list_with_authentication - assert 403 == 200
FAILED main_approver_test.py::test_lifecycle - assert 403 == 201
FAILED main_approver_test.py::test_donation - assert 403 == 201
FAILED main_nonapprover_test.py::test_list_subresources_with_authentication
FAILED main_nonapprover_test.py::test_insert_with_authentication - assert 403...
FAILED main_nonapprover_test.py::test_donation - assert 403 == 201
```