### PR TITLE
refactor: Terraform to seed causes and donations test data to Firestore

### DIFF
--- a/terraform/modules/emblem-app/files/templates/campaigns.tftpl
+++ b/terraform/modules/emblem-app/files/templates/campaigns.tftpl
@@ -1,0 +1,25 @@
+${jsonencode({
+    name = {
+        stringValue = name
+    }
+    description = {
+        stringValue = description
+    }
+    cause = {
+        stringValue = cause
+    }
+    managers = {
+        arrayValue = {
+            values =  [ for email in split(",", managers) : { "stringValue": email } ]
+        }
+    }
+    goal = {
+        integerValue = goal
+    }
+    imageUrl = {
+        stringValue = imageUrl
+    }
+    active = {
+        booleanValue = active
+    }
+})}

--- a/terraform/modules/emblem-app/files/templates/causes.tftpl
+++ b/terraform/modules/emblem-app/files/templates/causes.tftpl
@@ -1,0 +1,14 @@
+${jsonencode({
+    name = {
+        stringValue = name
+    }
+    description = {
+        stringValue = description
+    }
+    imageUrl = {
+        stringValue = imageUrl
+    }
+    active = {
+        booleanValue = active
+    }
+})}

--- a/terraform/modules/emblem-app/files/templates/donations.tftpl
+++ b/terraform/modules/emblem-app/files/templates/donations.tftpl
@@ -1,0 +1,11 @@
+${jsonencode({
+    campaign = {
+        stringValue = campaign
+    }
+    donor = {
+        stringValue = donor
+    }
+    amount = {
+        integerValue = amount
+    }
+})}

--- a/terraform/modules/emblem-app/files/test-data/campaigns.json
+++ b/terraform/modules/emblem-app/files/test-data/campaigns.json
@@ -1,0 +1,752 @@
+[
+    {
+        "collection": "campaigns",
+        "id": "59d32e9805fc4d3388db",
+        "data": {
+            "name": "Books for Ostriches needs your help!",
+            "description": "This time of year, Books for Ostriches could really use your help. Donate to my campaign to raise funds for Books for Ostriches today!",
+            "cause": "Books for Ostriches",
+            "managers": [
+                "user@example.com"
+            ],
+            "goal": 240,
+            "imageUrl": "https://upload.wikimedia.org/wikipedia/commons/thumb/6/65/Ostrich_%28Struthio_camelus%29_male_%2813994461256%29.jpg/2560px-Ostrich_%28Struthio_camelus%29_male_%2813994461256%29.jpg",
+            "active": true
+        }
+    },
+    {
+        "collection": "campaigns",
+        "id": "f1c4414d1fd74ab69969",
+        "data": {
+            "name": "Spare change for Meals for Dinosaurs",
+            "description": "Meals for Dinosaurs is a cause near and dear to my heart. Please support this impactful charity organization.",
+            "cause": "Meals for Dinosaurs",
+            "managers": [
+                "user@example.com"
+            ],
+            "goal": 2450,
+            "imageUrl": "https://upload.wikimedia.org/wikipedia/commons/thumb/e/ec/LA-Triceratops_mount-2.jpg/2560px-LA-Triceratops_mount-2.jpg",
+            "active": true
+        }
+    },
+    {
+        "collection": "campaigns",
+        "id": "826a7006c3d34ff9b65a",
+        "data": {
+            "name": "Retirement funds for Otters needs your help!",
+            "description": "Seeking funds for Retirement funds for Otters. Please help me reach my campaign goal.",
+            "cause": "Retirement funds for Otters",
+            "managers": [
+                "user@example.com"
+            ],
+            "goal": 5520,
+            "imageUrl": "https://upload.wikimedia.org/wikipedia/commons/thumb/9/9d/Water_Animal.jpg/2560px-Water_Animal.jpg",
+            "active": true
+        }
+    },
+    {
+        "collection": "campaigns",
+        "id": "c3b77518432a48d1ac0b",
+        "data": {
+            "name": "Be a hero - donate today",
+            "description": "Help make the world a better place by donating to Blankets for Tigers. All donations are tax-deductible!",
+            "cause": "Blankets for Tigers",
+            "managers": [
+                "user@example.com"
+            ],
+            "goal": 4410,
+            "imageUrl": "https://upload.wikimedia.org/wikipedia/commons/3/3f/Walking_tiger_female.jpg",
+            "active": true
+        }
+    },
+    {
+        "collection": "campaigns",
+        "id": "adf53a3c16cc470bbf03",
+        "data": {
+            "name": "Helping raise money for Hats for Tigers",
+            "description": "The best way to spend your fictitious money is by donating to a fictitious cause. Support Hats for Tigers and donate!",
+            "cause": "Hats for Tigers",
+            "managers": [
+                "user@example.com"
+            ],
+            "goal": 1550,
+            "imageUrl": "https://upload.wikimedia.org/wikipedia/commons/3/3f/Walking_tiger_female.jpg",
+            "active": true
+        }
+    },
+    {
+        "collection": "campaigns",
+        "id": "6747c2d7631d4763b1e6",
+        "data": {
+            "name": "Blankets for Tigers needs your help!",
+            "description": "Blankets for Tigers is a cause near and dear to my heart. Please support this impactful charity organization.",
+            "cause": "Blankets for Tigers",
+            "managers": [
+                "user@example.com"
+            ],
+            "goal": 760,
+            "imageUrl": "https://upload.wikimedia.org/wikipedia/commons/3/3f/Walking_tiger_female.jpg",
+            "active": true
+        }
+    },
+    {
+        "collection": "campaigns",
+        "id": "a87f8a72934749d9bbb8",
+        "data": {
+            "name": "Housing for Whales needs your money!",
+            "description": "Housing for Whales is a cause near and dear to my heart. Please support this impactful charity organization.",
+            "cause": "Housing for Whales",
+            "managers": [
+                "user@example.com"
+            ],
+            "goal": 360,
+            "imageUrl": "https://upload.wikimedia.org/wikipedia/commons/thumb/b/b1/Mother_and_baby_sperm_whale.jpg/2880px-Mother_and_baby_sperm_whale.jpg",
+            "active": true
+        }
+    },
+    {
+        "collection": "campaigns",
+        "id": "d9acf2caa90d45f2bcef",
+        "data": {
+            "name": "Hats for Tigers needs your money!",
+            "description": "Seeking funds for Hats for Tigers. Please help me reach my campaign goal.",
+            "cause": "Hats for Tigers",
+            "managers": [
+                "user@example.com"
+            ],
+            "goal": 60,
+            "imageUrl": "https://upload.wikimedia.org/wikipedia/commons/3/3f/Walking_tiger_female.jpg",
+            "active": true
+        }
+    },
+    {
+        "collection": "campaigns",
+        "id": "5c3d6313aae146c7b9db",
+        "data": {
+            "name": "Spare change for Transportation for Hamsters",
+            "description": "Help make the world a better place by donating to Transportation for Hamsters. All donations are tax-deductible!",
+            "cause": "Transportation for Hamsters",
+            "managers": [
+                "user@example.com"
+            ],
+            "goal": 420,
+            "imageUrl": "https://upload.wikimedia.org/wikipedia/commons/c/cd/Peach_the_pet_hamster.jpg",
+            "active": true
+        }
+    },
+    {
+        "collection": "campaigns",
+        "id": "71f3b299a95e430abb01",
+        "data": {
+            "name": "Help Transportation for Otters!",
+            "description": "Transportation for Otters is a cause near and dear to my heart. Please support this impactful charity organization.",
+            "cause": "Transportation for Otters",
+            "managers": [
+                "user@example.com"
+            ],
+            "goal": 1980,
+            "imageUrl": "https://upload.wikimedia.org/wikipedia/commons/thumb/9/9d/Water_Animal.jpg/2560px-Water_Animal.jpg",
+            "active": true
+        }
+    },
+    {
+        "collection": "campaigns",
+        "id": "e644ffc13e45476ab476",
+        "data": {
+            "name": "Collecting money to support Housing for Whales",
+            "description": "Seeking funds for Housing for Whales. Please help me reach my campaign goal.",
+            "cause": "Housing for Whales",
+            "managers": [
+                "user@example.com"
+            ],
+            "goal": 5280,
+            "imageUrl": "https://upload.wikimedia.org/wikipedia/commons/thumb/b/b1/Mother_and_baby_sperm_whale.jpg/2880px-Mother_and_baby_sperm_whale.jpg",
+            "active": true
+        }
+    },
+    {
+        "collection": "campaigns",
+        "id": "902110774a5146d08c96",
+        "data": {
+            "name": "Helping raise money for Food for Koalas",
+            "description": "Accepting donations for Food for Koalas. Help reach our fundraising goal and change the life of these needy creatures.",
+            "cause": "Food for Koalas",
+            "managers": [
+                "user@example.com"
+            ],
+            "goal": 8910,
+            "imageUrl": "https://upload.wikimedia.org/wikipedia/commons/4/49/Koala_climbing_tree.jpg",
+            "active": true
+        }
+    },
+    {
+        "collection": "campaigns",
+        "id": "f45a23d495f247cd907a",
+        "data": {
+            "name": "Help me reach my goal!",
+            "description": "Help make the world a better place by donating to Shelter for Otters. All donations are tax-deductible!",
+            "cause": "Shelter for Otters",
+            "managers": [
+                "user@example.com"
+            ],
+            "goal": 3360,
+            "imageUrl": "https://upload.wikimedia.org/wikipedia/commons/thumb/9/9d/Water_Animal.jpg/2560px-Water_Animal.jpg",
+            "active": true
+        }
+    },
+    {
+        "collection": "campaigns",
+        "id": "a2fad786f66e4405b3cc",
+        "data": {
+            "name": "Food for Seagulls needs your support!",
+            "description": "Fundraiser for Food for Seagulls",
+            "cause": "Food for Seagulls",
+            "managers": [
+                "user@example.com"
+            ],
+            "goal": 1520,
+            "imageUrl": "https://upload.wikimedia.org/wikipedia/commons/thumb/0/0b/Sea_Gull_at_Point_Lobos_State_Natural_Reserve%2C_CA.jpg/2560px-Sea_Gull_at_Point_Lobos_State_Natural_Reserve%2C_CA.jpg",
+            "active": true
+        }
+    },
+    {
+        "collection": "campaigns",
+        "id": "fcfcea59f46944b49305",
+        "data": {
+            "name": "Collecting money to support Coats for Dinosaurs",
+            "description": "Coats for Dinosaurs is a cause near and dear to my heart. Please support this impactful charity organization.",
+            "cause": "Coats for Dinosaurs",
+            "managers": [
+                "user@example.com"
+            ],
+            "goal": 580,
+            "imageUrl": "https://upload.wikimedia.org/wikipedia/commons/thumb/e/ec/LA-Triceratops_mount-2.jpg/2560px-LA-Triceratops_mount-2.jpg",
+            "active": true
+        }
+    },
+    {
+        "collection": "campaigns",
+        "id": "82d4f79423024eebab1e",
+        "data": {
+            "name": "Spare change for Food for Seagulls",
+            "description": "This time of year, Food for Seagulls could really use your help. Donate to my campaign to raise funds for Food for Seagulls today!",
+            "cause": "Food for Seagulls",
+            "managers": [
+                "user@example.com"
+            ],
+            "goal": 1520,
+            "imageUrl": "https://upload.wikimedia.org/wikipedia/commons/thumb/0/0b/Sea_Gull_at_Point_Lobos_State_Natural_Reserve%2C_CA.jpg/2560px-Sea_Gull_at_Point_Lobos_State_Natural_Reserve%2C_CA.jpg",
+            "active": true
+        }
+    },
+    {
+        "collection": "campaigns",
+        "id": "135c1666d5d24698b418",
+        "data": {
+            "name": "Be a hero - donate today",
+            "description": "Learn more about the worthy cause, Transportation for Otters, and help spread the word by donating to this campaign.",
+            "cause": "Transportation for Otters",
+            "managers": [
+                "user@example.com"
+            ],
+            "goal": 3200,
+            "imageUrl": "https://upload.wikimedia.org/wikipedia/commons/thumb/9/9d/Water_Animal.jpg/2560px-Water_Animal.jpg",
+            "active": true
+        }
+    },
+    {
+        "collection": "campaigns",
+        "id": "39bd8658cd754a7caae5",
+        "data": {
+            "name": "Transportation for Fish needs your money!",
+            "description": "Accepting donations for Transportation for Fish. Help reach our fundraising goal and change the life of these needy creatures.",
+            "cause": "Transportation for Fish",
+            "managers": [
+                "user@example.com"
+            ],
+            "goal": 3150,
+            "imageUrl": "https://upload.wikimedia.org/wikipedia/commons/2/23/Georgia_Aquarium_-_Giant_Grouper_edit.jpg",
+            "active": true
+        }
+    },
+    {
+        "collection": "campaigns",
+        "id": "95809499ae8a49f6a7db",
+        "data": {
+            "name": "Spare change for Careers for Fish",
+            "description": "Careers for Fish is a cause near and dear to my heart. Please support this impactful charity organization.",
+            "cause": "Careers for Fish",
+            "managers": [
+                "user@example.com"
+            ],
+            "goal": 3800,
+            "imageUrl": "https://upload.wikimedia.org/wikipedia/commons/2/23/Georgia_Aquarium_-_Giant_Grouper_edit.jpg",
+            "active": true
+        }
+    },
+    {
+        "collection": "campaigns",
+        "id": "7cc9ec1c70ac491799a3",
+        "data": {
+            "name": "Reaching out for Water for Eagles",
+            "description": "The best way to spend your fictitious money is by donating to a fictitious cause. Support Water for Eagles and donate!",
+            "cause": "Water for Eagles",
+            "managers": [
+                "user@example.com"
+            ],
+            "goal": 160,
+            "imageUrl": "https://upload.wikimedia.org/wikipedia/commons/1/19/%C3%81guila_calva.jpg",
+            "active": true
+        }
+    },
+    {
+        "collection": "campaigns",
+        "id": "19c0749c97b44616b60e",
+        "data": {
+            "name": "Reaching out for Books for Seagulls",
+            "description": "Can you spare a dime for Books for Seagulls? They do great work and need your help!",
+            "cause": "Books for Seagulls",
+            "managers": [
+                "user@example.com"
+            ],
+            "goal": 3440,
+            "imageUrl": "https://upload.wikimedia.org/wikipedia/commons/thumb/0/0b/Sea_Gull_at_Point_Lobos_State_Natural_Reserve%2C_CA.jpg/2560px-Sea_Gull_at_Point_Lobos_State_Natural_Reserve%2C_CA.jpg",
+            "active": true
+        }
+    },
+    {
+        "collection": "campaigns",
+        "id": "a45c093e8fbb4d8c8fce",
+        "data": {
+            "name": "Saving the world - with Retirement funds for Otters!",
+            "description": "Help make the world a better place by donating to Retirement funds for Otters. All donations are tax-deductible!",
+            "cause": "Retirement funds for Otters",
+            "managers": [
+                "user@example.com"
+            ],
+            "goal": 3320,
+            "imageUrl": "https://upload.wikimedia.org/wikipedia/commons/thumb/9/9d/Water_Animal.jpg/2560px-Water_Animal.jpg",
+            "active": true
+        }
+    },
+    {
+        "collection": "campaigns",
+        "id": "82fedc01135e44f4a3ca",
+        "data": {
+            "name": "Reaching out for Blankets for Tigers",
+            "description": "Seeking funds for Blankets for Tigers. Please help me reach my campaign goal.",
+            "cause": "Blankets for Tigers",
+            "managers": [
+                "user@example.com"
+            ],
+            "goal": 4550,
+            "imageUrl": "https://upload.wikimedia.org/wikipedia/commons/3/3f/Walking_tiger_female.jpg",
+            "active": true
+        }
+    },
+    {
+        "collection": "campaigns",
+        "id": "6d4afc70022941a4bb5e",
+        "data": {
+            "name": "Fundraiser for Retirement funds for Otters",
+            "description": "Can you spare a dime for Retirement funds for Otters? They do great work and need your help!",
+            "cause": "Retirement funds for Otters",
+            "managers": [
+                "user@example.com"
+            ],
+            "goal": 9400,
+            "imageUrl": "https://upload.wikimedia.org/wikipedia/commons/thumb/9/9d/Water_Animal.jpg/2560px-Water_Animal.jpg",
+            "active": true
+        }
+    },
+    {
+        "collection": "campaigns",
+        "id": "84f9424edf4e47de8e59",
+        "data": {
+            "name": "Water for Frogs needs your help!",
+            "description": "The best way to spend your fictitious money is by donating to a fictitious cause. Support Water for Frogs and donate!",
+            "cause": "Water for Frogs",
+            "managers": [
+                "user@example.com"
+            ],
+            "goal": 8550,
+            "imageUrl": "https://upload.wikimedia.org/wikipedia/commons/thumb/c/c1/Variegated_golden_frog_%28Mantella_baroni%29_Ranomafana.jpg/2560px-Variegated_golden_frog_%28Mantella_baroni%29_Ranomafana.jpg",
+            "active": true
+        }
+    },
+    {
+        "collection": "campaigns",
+        "id": "f810d8cd19ba4d5eaf99",
+        "data": {
+            "name": "Saving the world - with Retirement funds for Otters!",
+            "description": "Seeking funds for Retirement funds for Otters. Please help me reach my campaign goal.",
+            "cause": "Retirement funds for Otters",
+            "managers": [
+                "user@example.com"
+            ],
+            "goal": 1560,
+            "imageUrl": "https://upload.wikimedia.org/wikipedia/commons/thumb/9/9d/Water_Animal.jpg/2560px-Water_Animal.jpg",
+            "active": true
+        }
+    },
+    {
+        "collection": "campaigns",
+        "id": "7bde773588794af09e4e",
+        "data": {
+            "name": "Coats for Dinosaurs needs your money!",
+            "description": "Help make the world a better place by donating to Coats for Dinosaurs. All donations are tax-deductible!",
+            "cause": "Coats for Dinosaurs",
+            "managers": [
+                "user@example.com"
+            ],
+            "goal": 1680,
+            "imageUrl": "https://upload.wikimedia.org/wikipedia/commons/thumb/e/ec/LA-Triceratops_mount-2.jpg/2560px-LA-Triceratops_mount-2.jpg",
+            "active": true
+        }
+    },
+    {
+        "collection": "campaigns",
+        "id": "a918e7def61d4ee689b5",
+        "data": {
+            "name": "Spare change for Toys for Sharks",
+            "description": "Accepting donations for Toys for Sharks. Help reach our fundraising goal and change the life of these needy creatures.",
+            "cause": "Toys for Sharks",
+            "managers": [
+                "user@example.com"
+            ],
+            "goal": 9300,
+            "imageUrl": "https://upload.wikimedia.org/wikipedia/commons/8/83/Carcharhinus_leucas%2C_Koh_Phangan.jpg",
+            "active": true
+        }
+    },
+    {
+        "collection": "campaigns",
+        "id": "676160f83935418d8aff",
+        "data": {
+            "name": "Saving the world - with Water for Seagulls!",
+            "description": "Seeking funds for Water for Seagulls. Please help me reach my campaign goal.",
+            "cause": "Water for Seagulls",
+            "managers": [
+                "user@example.com"
+            ],
+            "goal": 2400,
+            "imageUrl": "https://upload.wikimedia.org/wikipedia/commons/thumb/0/0b/Sea_Gull_at_Point_Lobos_State_Natural_Reserve%2C_CA.jpg/2560px-Sea_Gull_at_Point_Lobos_State_Natural_Reserve%2C_CA.jpg",
+            "active": true
+        }
+    },
+    {
+        "collection": "campaigns",
+        "id": "826317093d784c9685bc",
+        "data": {
+            "name": "Collecting money to support Books for Ostriches",
+            "description": "Raising money to support Books for Ostriches",
+            "cause": "Books for Ostriches",
+            "managers": [
+                "user@example.com"
+            ],
+            "goal": 1520,
+            "imageUrl": "https://upload.wikimedia.org/wikipedia/commons/thumb/6/65/Ostrich_%28Struthio_camelus%29_male_%2813994461256%29.jpg/2560px-Ostrich_%28Struthio_camelus%29_male_%2813994461256%29.jpg",
+            "active": true
+        }
+    },
+    {
+        "collection": "campaigns",
+        "id": "96bd5b61cba941f1b6cb",
+        "data": {
+            "name": "Help Books for Bees!",
+            "description": "Can you spare a dime for Books for Bees? They do great work and need your help!",
+            "cause": "Books for Bees",
+            "managers": [
+                "user@example.com"
+            ],
+            "goal": 0,
+            "imageUrl": "https://upload.wikimedia.org/wikipedia/commons/thumb/4/49/Bumblebee_heuchera.jpg/1920px-Bumblebee_heuchera.jpg",
+            "active": true
+        }
+    },
+    {
+        "collection": "campaigns",
+        "id": "143b0c0bc68f4b56aff0",
+        "data": {
+            "name": "Reaching out for Transportation for Fish",
+            "description": "The best way to spend your fictitious money is by donating to a fictitious cause. Support Transportation for Fish and donate!",
+            "cause": "Transportation for Fish",
+            "managers": [
+                "user@example.com"
+            ],
+            "goal": 1000,
+            "imageUrl": "https://upload.wikimedia.org/wikipedia/commons/2/23/Georgia_Aquarium_-_Giant_Grouper_edit.jpg",
+            "active": true
+        }
+    },
+    {
+        "collection": "campaigns",
+        "id": "de87b3b760224638a9c1",
+        "data": {
+            "name": "Help Water for Seagulls!",
+            "description": "Help make the world a better place by donating to Water for Seagulls. All donations are tax-deductible!",
+            "cause": "Water for Seagulls",
+            "managers": [
+                "user@example.com"
+            ],
+            "goal": 1000,
+            "imageUrl": "https://upload.wikimedia.org/wikipedia/commons/thumb/0/0b/Sea_Gull_at_Point_Lobos_State_Natural_Reserve%2C_CA.jpg/2560px-Sea_Gull_at_Point_Lobos_State_Natural_Reserve%2C_CA.jpg",
+            "active": true
+        }
+    },
+    {
+        "collection": "campaigns",
+        "id": "b84da506508b4f52a6e6",
+        "data": {
+            "name": "Help me reach my goal!",
+            "description": "This time of year, Books for Seagulls could really use your help. Donate to my campaign to raise funds for Books for Seagulls today!",
+            "cause": "Books for Seagulls",
+            "managers": [
+                "user@example.com"
+            ],
+            "goal": 1710,
+            "imageUrl": "https://upload.wikimedia.org/wikipedia/commons/thumb/0/0b/Sea_Gull_at_Point_Lobos_State_Natural_Reserve%2C_CA.jpg/2560px-Sea_Gull_at_Point_Lobos_State_Natural_Reserve%2C_CA.jpg",
+            "active": true
+        }
+    },
+    {
+        "collection": "campaigns",
+        "id": "14cc3949063f48f696c4",
+        "data": {
+            "name": "Spare change for Water for Seagulls",
+            "description": "Seeking funds for Water for Seagulls. Please help me reach my campaign goal.",
+            "cause": "Water for Seagulls",
+            "managers": [
+                "user@example.com"
+            ],
+            "goal": 1540,
+            "imageUrl": "https://upload.wikimedia.org/wikipedia/commons/thumb/0/0b/Sea_Gull_at_Point_Lobos_State_Natural_Reserve%2C_CA.jpg/2560px-Sea_Gull_at_Point_Lobos_State_Natural_Reserve%2C_CA.jpg",
+            "active": true
+        }
+    },
+    {
+        "collection": "campaigns",
+        "id": "50d463d2c06440a186c9",
+        "data": {
+            "name": "Help Books for Ostriches reach their goal",
+            "description": "Fundraiser for Books for Ostriches",
+            "cause": "Books for Ostriches",
+            "managers": [
+                "user@example.com"
+            ],
+            "goal": 3550,
+            "imageUrl": "https://upload.wikimedia.org/wikipedia/commons/thumb/6/65/Ostrich_%28Struthio_camelus%29_male_%2813994461256%29.jpg/2560px-Ostrich_%28Struthio_camelus%29_male_%2813994461256%29.jpg",
+            "active": true
+        }
+    },
+    {
+        "collection": "campaigns",
+        "id": "633e95ea652e4484b5b3",
+        "data": {
+            "name": "Spare change for Bicycles for Hamsters",
+            "description": "Accepting donations for Bicycles for Hamsters. Help reach our fundraising goal and change the life of these needy creatures.",
+            "cause": "Bicycles for Hamsters",
+            "managers": [
+                "user@example.com"
+            ],
+            "goal": 2900,
+            "imageUrl": "https://upload.wikimedia.org/wikipedia/commons/c/cd/Peach_the_pet_hamster.jpg",
+            "active": true
+        }
+    },
+    {
+        "collection": "campaigns",
+        "id": "bccd31cd6c264449b8fa",
+        "data": {
+            "name": "Meals for Unicorns needs your money!",
+            "description": "Fundraiser for Meals for Unicorns",
+            "cause": "Meals for Unicorns",
+            "managers": [
+                "user@example.com"
+            ],
+            "goal": 1400,
+            "imageUrl": "https://upload.wikimedia.org/wikipedia/commons/7/70/Oftheunicorn.jpg",
+            "active": true
+        }
+    },
+    {
+        "collection": "campaigns",
+        "id": "8d98ea86e6644c72ac61",
+        "data": {
+            "name": "Helping raise money for Life-saving surgery for Sharks",
+            "description": "Raising money to support Life-saving surgery for Sharks",
+            "cause": "Life-saving surgery for Sharks",
+            "managers": [
+                "user@example.com"
+            ],
+            "goal": 3960,
+            "imageUrl": "https://upload.wikimedia.org/wikipedia/commons/8/83/Carcharhinus_leucas%2C_Koh_Phangan.jpg",
+            "active": true
+        }
+    },
+    {
+        "collection": "campaigns",
+        "id": "8811d0dff2504344a89b",
+        "data": {
+            "name": "Hats for Tigers needs your support!",
+            "description": "Learn more about the worthy cause, Hats for Tigers, and help spread the word by donating to this campaign.",
+            "cause": "Hats for Tigers",
+            "managers": [
+                "user@example.com"
+            ],
+            "goal": 1710,
+            "imageUrl": "https://upload.wikimedia.org/wikipedia/commons/3/3f/Walking_tiger_female.jpg",
+            "active": true
+        }
+    },
+    {
+        "collection": "campaigns",
+        "id": "75f374577ab147578cbe",
+        "data": {
+            "name": "Help Transportation for Hamsters!",
+            "description": "Accepting donations for Transportation for Hamsters. Help reach our fundraising goal and change the life of these needy creatures.",
+            "cause": "Transportation for Hamsters",
+            "managers": [
+                "user@example.com"
+            ],
+            "goal": 5180,
+            "imageUrl": "https://upload.wikimedia.org/wikipedia/commons/c/cd/Peach_the_pet_hamster.jpg",
+            "active": true
+        }
+    },
+    {
+        "collection": "campaigns",
+        "id": "d1860129237b4299b5f8",
+        "data": {
+            "name": "Raising funds for Books for Bees",
+            "description": "This time of year, Books for Bees could really use your help. Donate to my campaign to raise funds for Books for Bees today!",
+            "cause": "Books for Bees",
+            "managers": [
+                "user@example.com"
+            ],
+            "goal": 1600,
+            "imageUrl": "https://upload.wikimedia.org/wikipedia/commons/thumb/4/49/Bumblebee_heuchera.jpg/1920px-Bumblebee_heuchera.jpg",
+            "active": true
+        }
+    },
+    {
+        "collection": "campaigns",
+        "id": "46bc552cd9714b5ab9a1",
+        "data": {
+            "name": "Help Books for Bees reach their goal",
+            "description": "Accepting donations for Books for Bees. Help reach our fundraising goal and change the life of these needy creatures.",
+            "cause": "Books for Bees",
+            "managers": [
+                "user@example.com"
+            ],
+            "goal": 950,
+            "imageUrl": "https://upload.wikimedia.org/wikipedia/commons/thumb/4/49/Bumblebee_heuchera.jpg/1920px-Bumblebee_heuchera.jpg",
+            "active": true
+        }
+    },
+    {
+        "collection": "campaigns",
+        "id": "b9c219c4a3f5498d96e2",
+        "data": {
+            "name": "Raising funds for Coats for Sharks",
+            "description": "Seeking funds for Coats for Sharks. Please help me reach my campaign goal.",
+            "cause": "Coats for Sharks",
+            "managers": [
+                "user@example.com"
+            ],
+            "goal": 3300,
+            "imageUrl": "https://upload.wikimedia.org/wikipedia/commons/8/83/Carcharhinus_leucas%2C_Koh_Phangan.jpg",
+            "active": true
+        }
+    },
+    {
+        "collection": "campaigns",
+        "id": "bae04507c523429fa045",
+        "data": {
+            "name": "Saving the world - with Toys for Sharks!",
+            "description": "Fundraiser for Toys for Sharks",
+            "cause": "Toys for Sharks",
+            "managers": [
+                "user@example.com"
+            ],
+            "goal": 520,
+            "imageUrl": "https://upload.wikimedia.org/wikipedia/commons/8/83/Carcharhinus_leucas%2C_Koh_Phangan.jpg",
+            "active": true
+        }
+    },
+    {
+        "collection": "campaigns",
+        "id": "aae62c8c38d047efa868",
+        "data": {
+            "name": "Fundraiser for Water for Frogs",
+            "description": "Can you spare a dime for Water for Frogs? They do great work and need your help!",
+            "cause": "Water for Frogs",
+            "managers": [
+                "user@example.com"
+            ],
+            "goal": 550,
+            "imageUrl": "https://upload.wikimedia.org/wikipedia/commons/thumb/c/c1/Variegated_golden_frog_%28Mantella_baroni%29_Ranomafana.jpg/2560px-Variegated_golden_frog_%28Mantella_baroni%29_Ranomafana.jpg",
+            "active": true
+        }
+    },
+    {
+        "collection": "campaigns",
+        "id": "d862f4a1e42e4ed7a01c",
+        "data": {
+            "name": "Saving the world - with Clean water for Mice!",
+            "description": "Learn more about the worthy cause, Clean water for Mice, and help spread the word by donating to this campaign.",
+            "cause": "Clean water for Mice",
+            "managers": [
+                "user@example.com"
+            ],
+            "goal": 2160,
+            "imageUrl": "https://upload.wikimedia.org/wikipedia/commons/8/8f/Mouse_white_background.jpg",
+            "active": true
+        }
+    },
+    {
+        "collection": "campaigns",
+        "id": "a5b2b63d6ef44b37b993",
+        "data": {
+            "name": "Help Life-saving surgery for Ostriches reach their goal",
+            "description": "The best way to spend your fictitious money is by donating to a fictitious cause. Support Life-saving surgery for Ostriches and donate!",
+            "cause": "Life-saving surgery for Ostriches",
+            "managers": [
+                "user@example.com"
+            ],
+            "goal": 2360,
+            "imageUrl": "https://upload.wikimedia.org/wikipedia/commons/thumb/6/65/Ostrich_%28Struthio_camelus%29_male_%2813994461256%29.jpg/2560px-Ostrich_%28Struthio_camelus%29_male_%2813994461256%29.jpg",
+            "active": true
+        }
+    },
+    {
+        "collection": "campaigns",
+        "id": "8e69b7b425c748d8a2d1",
+        "data": {
+            "name": "Reaching out for Food for Dinosaurs",
+            "description": "The best way to spend your fictitious money is by donating to a fictitious cause. Support Food for Dinosaurs and donate!",
+            "cause": "Food for Dinosaurs",
+            "managers": [
+                "user@example.com"
+            ],
+            "goal": 8010,
+            "imageUrl": "https://upload.wikimedia.org/wikipedia/commons/thumb/e/ec/LA-Triceratops_mount-2.jpg/2560px-LA-Triceratops_mount-2.jpg",
+            "active": true
+        }
+    },
+    {
+        "collection": "campaigns",
+        "id": "1702615c336147219891",
+        "data": {
+            "name": "Collecting money to support Housing for Dinosaurs",
+            "description": "Accepting donations for Housing for Dinosaurs. Help reach our fundraising goal and change the life of these needy creatures.",
+            "cause": "Housing for Dinosaurs",
+            "managers": [
+                "user@example.com"
+            ],
+            "goal": 9100,
+            "imageUrl": "https://upload.wikimedia.org/wikipedia/commons/thumb/e/ec/LA-Triceratops_mount-2.jpg/2560px-LA-Triceratops_mount-2.jpg",
+            "active": true
+        }
+    }
+]

--- a/terraform/modules/emblem-app/files/test-data/causes.json
+++ b/terraform/modules/emblem-app/files/test-data/causes.json
@@ -1,0 +1,502 @@
+[
+    {
+        "collection": "causes",
+        "id": "959e58da66dd455b80dd",
+        "data": {
+            "name": "Housing for Eagles",
+            "description": "This cause provides housing for harmed eagles.",
+            "imageUrl": "https://upload.wikimedia.org/wikipedia/commons/1/19/%C3%81guila_calva.jpg",
+            "active": true
+        }
+    },
+    {
+        "collection": "causes",
+        "id": "e0a8daf0cb7c4b0fbce8",
+        "data": {
+            "name": "Meals for Unicorns",
+            "description": "This cause provides meals for hungry unicorns.",
+            "imageUrl": "https://upload.wikimedia.org/wikipedia/commons/7/70/Oftheunicorn.jpg",
+            "active": true
+        }
+    },
+    {
+        "collection": "causes",
+        "id": "ccbdbdb4ee7d47878fc5",
+        "data": {
+            "name": "Food for Dinosaurs",
+            "description": "This cause provides food for gifted dinosaurs.",
+            "imageUrl": "https://upload.wikimedia.org/wikipedia/commons/thumb/e/ec/LA-Triceratops_mount-2.jpg/2560px-LA-Triceratops_mount-2.jpg",
+            "active": true
+        }
+    },
+    {
+        "collection": "causes",
+        "id": "c4469b79cc074ebc980a",
+        "data": {
+            "name": "Housing for Whales",
+            "description": "This cause provides housing for unhoused whales.",
+            "imageUrl": "https://upload.wikimedia.org/wikipedia/commons/thumb/b/b1/Mother_and_baby_sperm_whale.jpg/2880px-Mother_and_baby_sperm_whale.jpg",
+            "active": true
+        }
+    },
+    {
+        "collection": "causes",
+        "id": "6aee60eead3741a98f15",
+        "data": {
+            "name": "Blankets for Tigers",
+            "description": "This cause provides blankets for underprivileged tigers.",
+            "imageUrl": "https://upload.wikimedia.org/wikipedia/commons/3/3f/Walking_tiger_female.jpg",
+            "active": true
+        }
+    },
+    {
+        "collection": "causes",
+        "id": "7af2faa3201148d4b9cc",
+        "data": {
+            "name": "Cars for Sharks",
+            "description": "This cause provides cars for injured sharks.",
+            "imageUrl": "https://upload.wikimedia.org/wikipedia/commons/8/83/Carcharhinus_leucas%2C_Koh_Phangan.jpg",
+            "active": true
+        }
+    },
+    {
+        "collection": "causes",
+        "id": "7fdfb0f40b704ce7ac85",
+        "data": {
+            "name": "Toys for Frogs",
+            "description": "This cause provides toys for impoverished frogs.",
+            "imageUrl": "https://upload.wikimedia.org/wikipedia/commons/thumb/c/c1/Variegated_golden_frog_%28Mantella_baroni%29_Ranomafana.jpg/2560px-Variegated_golden_frog_%28Mantella_baroni%29_Ranomafana.jpg",
+            "active": true
+        }
+    },
+    {
+        "collection": "causes",
+        "id": "33121a08b7cf4c478e2a",
+        "data": {
+            "name": "Coats for Seagulls",
+            "description": "This cause provides coats for ailing seagulls.",
+            "imageUrl": "https://upload.wikimedia.org/wikipedia/commons/thumb/0/0b/Sea_Gull_at_Point_Lobos_State_Natural_Reserve%2C_CA.jpg/2560px-Sea_Gull_at_Point_Lobos_State_Natural_Reserve%2C_CA.jpg",
+            "active": true
+        }
+    },
+    {
+        "collection": "causes",
+        "id": "7b2ce428289f4ea09bab",
+        "data": {
+            "name": "Coats for Tigers",
+            "description": "This cause provides coats for hard-working tigers.",
+            "imageUrl": "https://upload.wikimedia.org/wikipedia/commons/3/3f/Walking_tiger_female.jpg",
+            "active": true
+        }
+    },
+    {
+        "collection": "causes",
+        "id": "1c3d04677be84278ba65",
+        "data": {
+            "name": "Hats for Tigers",
+            "description": "This cause provides hats for hard-working tigers.",
+            "imageUrl": "https://upload.wikimedia.org/wikipedia/commons/3/3f/Walking_tiger_female.jpg",
+            "active": true
+        }
+    },
+    {
+        "collection": "causes",
+        "id": "fcf5769652df406db5d6",
+        "data": {
+            "name": "Transportation for Otters",
+            "description": "This cause provides transportation for inspirational otters.",
+            "imageUrl": "https://upload.wikimedia.org/wikipedia/commons/thumb/9/9d/Water_Animal.jpg/2560px-Water_Animal.jpg",
+            "active": true
+        }
+    },
+    {
+        "collection": "causes",
+        "id": "a71470fa7502426aa568",
+        "data": {
+            "name": "Housing for Dinosaurs",
+            "description": "This cause provides housing for mistreated dinosaurs.",
+            "imageUrl": "https://upload.wikimedia.org/wikipedia/commons/thumb/e/ec/LA-Triceratops_mount-2.jpg/2560px-LA-Triceratops_mount-2.jpg",
+            "active": true
+        }
+    },
+    {
+        "collection": "causes",
+        "id": "6fd1f9b244584ff19b2c",
+        "data": {
+            "name": "Books for Bees",
+            "description": "This cause provides books for displaced bees.",
+            "imageUrl": "https://upload.wikimedia.org/wikipedia/commons/thumb/4/49/Bumblebee_heuchera.jpg/1920px-Bumblebee_heuchera.jpg",
+            "active": true
+        }
+    },
+    {
+        "collection": "causes",
+        "id": "a2b7764b6be54e2ca14f",
+        "data": {
+            "name": "Retirement funds for Fish",
+            "description": "This cause provides retirement funds for unhoused fish.",
+            "imageUrl": "https://upload.wikimedia.org/wikipedia/commons/2/23/Georgia_Aquarium_-_Giant_Grouper_edit.jpg",
+            "active": true
+        }
+    },
+    {
+        "collection": "causes",
+        "id": "7612387d8bfb43feb5cd",
+        "data": {
+            "name": "Books for Mice",
+            "description": "This cause provides books for deprived mice.",
+            "imageUrl": "https://upload.wikimedia.org/wikipedia/commons/8/8f/Mouse_white_background.jpg",
+            "active": true
+        }
+    },
+    {
+        "collection": "causes",
+        "id": "1ca722dbe31e43c8bd4f",
+        "data": {
+            "name": "Clean water for Mice",
+            "description": "This cause provides clean water for ailing mice.",
+            "imageUrl": "https://upload.wikimedia.org/wikipedia/commons/8/8f/Mouse_white_background.jpg",
+            "active": true
+        }
+    },
+    {
+        "collection": "causes",
+        "id": "cb31824198274f04a599",
+        "data": {
+            "name": "Cars for Koalas",
+            "description": "This cause provides cars for gifted koalas.",
+            "imageUrl": "https://upload.wikimedia.org/wikipedia/commons/4/49/Koala_climbing_tree.jpg",
+            "active": true
+        }
+    },
+    {
+        "collection": "causes",
+        "id": "dbf7724ebcd04f708568",
+        "data": {
+            "name": "Books for Bees",
+            "description": "This cause provides books for distressed bees.",
+            "imageUrl": "https://upload.wikimedia.org/wikipedia/commons/thumb/4/49/Bumblebee_heuchera.jpg/1920px-Bumblebee_heuchera.jpg",
+            "active": true
+        }
+    },
+    {
+        "collection": "causes",
+        "id": "56b2b391f4364203bdd3",
+        "data": {
+            "name": "Water for Seagulls",
+            "description": "This cause provides water for injured seagulls.",
+            "imageUrl": "https://upload.wikimedia.org/wikipedia/commons/thumb/0/0b/Sea_Gull_at_Point_Lobos_State_Natural_Reserve%2C_CA.jpg/2560px-Sea_Gull_at_Point_Lobos_State_Natural_Reserve%2C_CA.jpg",
+            "active": true
+        }
+    },
+    {
+        "collection": "causes",
+        "id": "684dfd4302aa459ab64e",
+        "data": {
+            "name": "Transportation for Fish",
+            "description": "This cause provides transportation for hungry fish.",
+            "imageUrl": "https://upload.wikimedia.org/wikipedia/commons/2/23/Georgia_Aquarium_-_Giant_Grouper_edit.jpg",
+            "active": true
+        }
+    },
+    {
+        "collection": "causes",
+        "id": "2a0644d1e52241728c73",
+        "data": {
+            "name": "Books for Ostriches",
+            "description": "This cause provides books for ailing ostriches.",
+            "imageUrl": "https://upload.wikimedia.org/wikipedia/commons/thumb/6/65/Ostrich_%28Struthio_camelus%29_male_%2813994461256%29.jpg/2560px-Ostrich_%28Struthio_camelus%29_male_%2813994461256%29.jpg",
+            "active": true
+        }
+    },
+    {
+        "collection": "causes",
+        "id": "97f5269205614b2fac4f",
+        "data": {
+            "name": "Food for Seagulls",
+            "description": "This cause provides food for displaced seagulls.",
+            "imageUrl": "https://upload.wikimedia.org/wikipedia/commons/thumb/0/0b/Sea_Gull_at_Point_Lobos_State_Natural_Reserve%2C_CA.jpg/2560px-Sea_Gull_at_Point_Lobos_State_Natural_Reserve%2C_CA.jpg",
+            "active": true
+        }
+    },
+    {
+        "collection": "causes",
+        "id": "8204bff6f726489eb62f",
+        "data": {
+            "name": "Cars for Fish",
+            "description": "This cause provides cars for impoverished fish.",
+            "imageUrl": "https://upload.wikimedia.org/wikipedia/commons/2/23/Georgia_Aquarium_-_Giant_Grouper_edit.jpg",
+            "active": true
+        }
+    },
+    {
+        "collection": "causes",
+        "id": "9ae962f485134bb6875e",
+        "data": {
+            "name": "Occupational therapy for Mice",
+            "description": "This cause provides occupational therapy for destitute mice.",
+            "imageUrl": "https://upload.wikimedia.org/wikipedia/commons/8/8f/Mouse_white_background.jpg",
+            "active": true
+        }
+    },
+    {
+        "collection": "causes",
+        "id": "8534622179f04f43920b",
+        "data": {
+            "name": "Life-saving surgery for Ostriches",
+            "description": "This cause provides life-saving surgery for deprived ostriches.",
+            "imageUrl": "https://upload.wikimedia.org/wikipedia/commons/thumb/6/65/Ostrich_%28Struthio_camelus%29_male_%2813994461256%29.jpg/2560px-Ostrich_%28Struthio_camelus%29_male_%2813994461256%29.jpg",
+            "active": true
+        }
+    },
+    {
+        "collection": "causes",
+        "id": "fc26c04d43244c069fe4",
+        "data": {
+            "name": "Food for Mice",
+            "description": "This cause provides food for gifted mice.",
+            "imageUrl": "https://upload.wikimedia.org/wikipedia/commons/8/8f/Mouse_white_background.jpg",
+            "active": true
+        }
+    },
+    {
+        "collection": "causes",
+        "id": "9b32a2aa26cd423cbfa3",
+        "data": {
+            "name": "Retirement funds for Otters",
+            "description": "This cause provides retirement funds for disadvantaged otters.",
+            "imageUrl": "https://upload.wikimedia.org/wikipedia/commons/thumb/9/9d/Water_Animal.jpg/2560px-Water_Animal.jpg",
+            "active": true
+        }
+    },
+    {
+        "collection": "causes",
+        "id": "afb97ea9703748f1ae5e",
+        "data": {
+            "name": "Blankets for Tigers",
+            "description": "This cause provides blankets for disadvantaged tigers.",
+            "imageUrl": "https://upload.wikimedia.org/wikipedia/commons/3/3f/Walking_tiger_female.jpg",
+            "active": true
+        }
+    },
+    {
+        "collection": "causes",
+        "id": "ccedb0d3ca5644d19501",
+        "data": {
+            "name": "Shelter for Otters",
+            "description": "This cause provides shelter for underprivileged otters.",
+            "imageUrl": "https://upload.wikimedia.org/wikipedia/commons/thumb/9/9d/Water_Animal.jpg/2560px-Water_Animal.jpg",
+            "active": true
+        }
+    },
+    {
+        "collection": "causes",
+        "id": "7ffbf17712f547dbb7a9",
+        "data": {
+            "name": "Meals for Frogs",
+            "description": "This cause provides meals for under-served frogs.",
+            "imageUrl": "https://upload.wikimedia.org/wikipedia/commons/thumb/c/c1/Variegated_golden_frog_%28Mantella_baroni%29_Ranomafana.jpg/2560px-Variegated_golden_frog_%28Mantella_baroni%29_Ranomafana.jpg",
+            "active": true
+        }
+    },
+    {
+        "collection": "causes",
+        "id": "a70864b373434e7bada2",
+        "data": {
+            "name": "Cars for Unicorns",
+            "description": "This cause provides cars for deprived unicorns.",
+            "imageUrl": "https://upload.wikimedia.org/wikipedia/commons/7/70/Oftheunicorn.jpg",
+            "active": true
+        }
+    },
+    {
+        "collection": "causes",
+        "id": "cb0708d2ec634828aaa5",
+        "data": {
+            "name": "Hats for Mice",
+            "description": "This cause provides hats for gifted mice.",
+            "imageUrl": "https://upload.wikimedia.org/wikipedia/commons/8/8f/Mouse_white_background.jpg",
+            "active": true
+        }
+    },
+    {
+        "collection": "causes",
+        "id": "dbe6439da7784d9884a4",
+        "data": {
+            "name": "Blankets for Camels",
+            "description": "This cause provides blankets for unhoused camels.",
+            "imageUrl": "https://upload.wikimedia.org/wikipedia/commons/6/6a/Bactrian_Camel.jpg",
+            "active": true
+        }
+    },
+    {
+        "collection": "causes",
+        "id": "f39002326ea645109492",
+        "data": {
+            "name": "Life-saving surgery for Sharks",
+            "description": "This cause provides life-saving surgery for gifted sharks.",
+            "imageUrl": "https://upload.wikimedia.org/wikipedia/commons/8/83/Carcharhinus_leucas%2C_Koh_Phangan.jpg",
+            "active": true
+        }
+    },
+    {
+        "collection": "causes",
+        "id": "4105941c50ce4c929dba",
+        "data": {
+            "name": "Water for Frogs",
+            "description": "This cause provides water for deprived frogs.",
+            "imageUrl": "https://upload.wikimedia.org/wikipedia/commons/thumb/c/c1/Variegated_golden_frog_%28Mantella_baroni%29_Ranomafana.jpg/2560px-Variegated_golden_frog_%28Mantella_baroni%29_Ranomafana.jpg",
+            "active": true
+        }
+    },
+    {
+        "collection": "causes",
+        "id": "b4c9faccae1148279be6",
+        "data": {
+            "name": "Food for Koalas",
+            "description": "This cause provides food for endangered koalas.",
+            "imageUrl": "https://upload.wikimedia.org/wikipedia/commons/4/49/Koala_climbing_tree.jpg",
+            "active": true
+        }
+    },
+    {
+        "collection": "causes",
+        "id": "f92fda62b7c943dba0b2",
+        "data": {
+            "name": "Bicycles for Hamsters",
+            "description": "This cause provides bicycles for distressed hamsters.",
+            "imageUrl": "https://upload.wikimedia.org/wikipedia/commons/c/cd/Peach_the_pet_hamster.jpg",
+            "active": true
+        }
+    },
+    {
+        "collection": "causes",
+        "id": "a5cf9489945741e8b37b",
+        "data": {
+            "name": "Hats for Frogs",
+            "description": "This cause provides hats for impoverished frogs.",
+            "imageUrl": "https://upload.wikimedia.org/wikipedia/commons/thumb/c/c1/Variegated_golden_frog_%28Mantella_baroni%29_Ranomafana.jpg/2560px-Variegated_golden_frog_%28Mantella_baroni%29_Ranomafana.jpg",
+            "active": true
+        }
+    },
+    {
+        "collection": "causes",
+        "id": "9d6efb1521d6493c98fc",
+        "data": {
+            "name": "Meals for Bees",
+            "description": "This cause provides meals for impoverished bees.",
+            "imageUrl": "https://upload.wikimedia.org/wikipedia/commons/thumb/4/49/Bumblebee_heuchera.jpg/1920px-Bumblebee_heuchera.jpg",
+            "active": true
+        }
+    },
+    {
+        "collection": "causes",
+        "id": "d553d53830844047a732",
+        "data": {
+            "name": "Transportation for Hamsters",
+            "description": "This cause provides transportation for under-served hamsters.",
+            "imageUrl": "https://upload.wikimedia.org/wikipedia/commons/c/cd/Peach_the_pet_hamster.jpg",
+            "active": true
+        }
+    },
+    {
+        "collection": "causes",
+        "id": "5f734b507b3c4ccab247",
+        "data": {
+            "name": "Meals for Dinosaurs",
+            "description": "This cause provides meals for gifted dinosaurs.",
+            "imageUrl": "https://upload.wikimedia.org/wikipedia/commons/thumb/e/ec/LA-Triceratops_mount-2.jpg/2560px-LA-Triceratops_mount-2.jpg",
+            "active": true
+        }
+    },
+    {
+        "collection": "causes",
+        "id": "369bb3831ef1424bb06c",
+        "data": {
+            "name": "Water for Eagles",
+            "description": "This cause provides water for under-served eagles.",
+            "imageUrl": "https://upload.wikimedia.org/wikipedia/commons/1/19/%C3%81guila_calva.jpg",
+            "active": true
+        }
+    },
+    {
+        "collection": "causes",
+        "id": "9ddf4f873158425781db",
+        "data": {
+            "name": "Retirement funds for Otters",
+            "description": "This cause provides retirement funds for deprived otters.",
+            "imageUrl": "https://upload.wikimedia.org/wikipedia/commons/thumb/9/9d/Water_Animal.jpg/2560px-Water_Animal.jpg",
+            "active": true
+        }
+    },
+    {
+        "collection": "causes",
+        "id": "8561257ef7cf48b4bb46",
+        "data": {
+            "name": "Toys for Sharks",
+            "description": "This cause provides toys for gifted sharks.",
+            "imageUrl": "https://upload.wikimedia.org/wikipedia/commons/8/83/Carcharhinus_leucas%2C_Koh_Phangan.jpg",
+            "active": true
+        }
+    },
+    {
+        "collection": "causes",
+        "id": "9b88e63ede6e49cf8000",
+        "data": {
+            "name": "Coats for Sharks",
+            "description": "This cause provides coats for inspirational sharks.",
+            "imageUrl": "https://upload.wikimedia.org/wikipedia/commons/8/83/Carcharhinus_leucas%2C_Koh_Phangan.jpg",
+            "active": true
+        }
+    },
+    {
+        "collection": "causes",
+        "id": "4c308254020b407cb6c7",
+        "data": {
+            "name": "Books for Seagulls",
+            "description": "This cause provides books for hard-working seagulls.",
+            "imageUrl": "https://upload.wikimedia.org/wikipedia/commons/thumb/0/0b/Sea_Gull_at_Point_Lobos_State_Natural_Reserve%2C_CA.jpg/2560px-Sea_Gull_at_Point_Lobos_State_Natural_Reserve%2C_CA.jpg",
+            "active": true
+        }
+    },
+    {
+        "collection": "causes",
+        "id": "f390d92c0ae349629c0f",
+        "data": {
+            "name": "Life-saving surgery for Trees",
+            "description": "This cause provides life-saving surgery for displaced trees.",
+            "imageUrl": "https://upload.wikimedia.org/wikipedia/commons/thumb/c/ca/Larix_decidua_Aletschwald.jpg/1280px-Larix_decidua_Aletschwald.jpg",
+            "active": true
+        }
+    },
+    {
+        "collection": "causes",
+        "id": "889a5efa7b9b490dafa3",
+        "data": {
+            "name": "Clean water for Mice",
+            "description": "This cause provides clean water for distressed mice.",
+            "imageUrl": "https://upload.wikimedia.org/wikipedia/commons/8/8f/Mouse_white_background.jpg",
+            "active": true
+        }
+    },
+    {
+        "collection": "causes",
+        "id": "4c70905a83484dbd838d",
+        "data": {
+            "name": "Coats for Dinosaurs",
+            "description": "This cause provides coats for distressed dinosaurs.",
+            "imageUrl": "https://upload.wikimedia.org/wikipedia/commons/thumb/e/ec/LA-Triceratops_mount-2.jpg/2560px-LA-Triceratops_mount-2.jpg",
+            "active": true
+        }
+    },
+    {
+        "collection": "causes",
+        "id": "25f74d2c1805452db0a9",
+        "data": {
+            "name": "Careers for Fish",
+            "description": "This cause provides careers for gifted fish.",
+            "imageUrl": "https://upload.wikimedia.org/wikipedia/commons/2/23/Georgia_Aquarium_-_Giant_Grouper_edit.jpg",
+            "active": true
+        }
+    }
+]

--- a/terraform/modules/emblem-app/files/test-data/donations.json
+++ b/terraform/modules/emblem-app/files/test-data/donations.json
@@ -1,0 +1,902 @@
+[
+    {
+        "collection": "donations",
+        "id": "f5ea984abf29497bbed7",
+        "data": {
+            "campaign": "c3b77518432a48d1ac0b",
+            "donor": "844d9e35d64c4409ba64",
+            "amount": 315
+        }
+    },
+    {
+        "collection": "donations",
+        "id": "7c8e065bd24146ce95ac",
+        "data": {
+            "campaign": "902110774a5146d08c96",
+            "donor": "b0703a8917ae4983b5e2",
+            "amount": 45
+        }
+    },
+    {
+        "collection": "donations",
+        "id": "517096e2c152477f8041",
+        "data": {
+            "campaign": "902110774a5146d08c96",
+            "donor": "d01a034a64f14ab2a87b",
+            "amount": 240
+        }
+    },
+    {
+        "collection": "donations",
+        "id": "466fc6d8325042a3b875",
+        "data": {
+            "campaign": "d862f4a1e42e4ed7a01c",
+            "donor": "913349c0d8e34dedaba7",
+            "amount": 135
+        }
+    },
+    {
+        "collection": "donations",
+        "id": "b4570b95550448e99666",
+        "data": {
+            "campaign": "bccd31cd6c264449b8fa",
+            "donor": "368ee1c2bebd47c48a00",
+            "amount": 20
+        }
+    },
+    {
+        "collection": "donations",
+        "id": "83887b7d1dd44828a3cf",
+        "data": {
+            "campaign": "6d4afc70022941a4bb5e",
+            "donor": "8c338098ca07442598d1",
+            "amount": 105
+        }
+    },
+    {
+        "collection": "donations",
+        "id": "5c8e649aaaba499380b5",
+        "data": {
+            "campaign": "f1c4414d1fd74ab69969",
+            "donor": "913349c0d8e34dedaba7",
+            "amount": 60
+        }
+    },
+    {
+        "collection": "donations",
+        "id": "eaf52e1488654889b43d",
+        "data": {
+            "campaign": "f45a23d495f247cd907a",
+            "donor": "7e2d40bce50248faa2b4",
+            "amount": 280
+        }
+    },
+    {
+        "collection": "donations",
+        "id": "04a7d53a2d94415bb327",
+        "data": {
+            "campaign": "8811d0dff2504344a89b",
+            "donor": "e734b9c771ac46c48767",
+            "amount": 40
+        }
+    },
+    {
+        "collection": "donations",
+        "id": "cd5298ca48134c289636",
+        "data": {
+            "campaign": "826317093d784c9685bc",
+            "donor": "c8a5e4fc3c1942449044",
+            "amount": 105
+        }
+    },
+    {
+        "collection": "donations",
+        "id": "734e6e8d23de4fa8a3d1",
+        "data": {
+            "campaign": "143b0c0bc68f4b56aff0",
+            "donor": "c38ee984164746879a0f",
+            "amount": 100
+        }
+    },
+    {
+        "collection": "donations",
+        "id": "562ad7012deb486e8800",
+        "data": {
+            "campaign": "75f374577ab147578cbe",
+            "donor": "57d62f566516411e98eb",
+            "amount": 270
+        }
+    },
+    {
+        "collection": "donations",
+        "id": "56f2b67ef8ea49ee95fe",
+        "data": {
+            "campaign": "82d4f79423024eebab1e",
+            "donor": "8a81ed5989d34ca09165",
+            "amount": 125
+        }
+    },
+    {
+        "collection": "donations",
+        "id": "5c279454a5f849a4acc2",
+        "data": {
+            "campaign": "b9c219c4a3f5498d96e2",
+            "donor": "0bdb59ccc56f4cb3b023",
+            "amount": 360
+        }
+    },
+    {
+        "collection": "donations",
+        "id": "293dd1f6de5e4b21b371",
+        "data": {
+            "campaign": "a918e7def61d4ee689b5",
+            "donor": "de70db52648c4a82b312",
+            "amount": 70
+        }
+    },
+    {
+        "collection": "donations",
+        "id": "16d0d2f5da124860a82c",
+        "data": {
+            "campaign": "826a7006c3d34ff9b65a",
+            "donor": "1dd769f312ec4d0b8701",
+            "amount": 240
+        }
+    },
+    {
+        "collection": "donations",
+        "id": "fe12958731cf4502b42b",
+        "data": {
+            "campaign": "633e95ea652e4484b5b3",
+            "donor": "68a994518d354b2e9ec4",
+            "amount": 270
+        }
+    },
+    {
+        "collection": "donations",
+        "id": "699645e4ff47452f8a26",
+        "data": {
+            "campaign": "f1c4414d1fd74ab69969",
+            "donor": "cc9f4b1da9154c4488d6",
+            "amount": 210
+        }
+    },
+    {
+        "collection": "donations",
+        "id": "9125ecced99c434aac50",
+        "data": {
+            "campaign": "d862f4a1e42e4ed7a01c",
+            "donor": "913349c0d8e34dedaba7",
+            "amount": 20
+        }
+    },
+    {
+        "collection": "donations",
+        "id": "75e342e7da094ce29b7a",
+        "data": {
+            "campaign": "a918e7def61d4ee689b5",
+            "donor": "b33ef37d391d40b48180",
+            "amount": 280
+        }
+    },
+    {
+        "collection": "donations",
+        "id": "06d04a43cfa14a2cab53",
+        "data": {
+            "campaign": "14cc3949063f48f696c4",
+            "donor": "80403302ad614b1e9004",
+            "amount": 40
+        }
+    },
+    {
+        "collection": "donations",
+        "id": "e7777786ee6247429a6e",
+        "data": {
+            "campaign": "7cc9ec1c70ac491799a3",
+            "donor": "844d9e35d64c4409ba64",
+            "amount": 45
+        }
+    },
+    {
+        "collection": "donations",
+        "id": "f14c183090114c929d84",
+        "data": {
+            "campaign": "826a7006c3d34ff9b65a",
+            "donor": "a93deec7cb9e47499426",
+            "amount": 5
+        }
+    },
+    {
+        "collection": "donations",
+        "id": "d85500a79a4e4c5682f1",
+        "data": {
+            "campaign": "50d463d2c06440a186c9",
+            "donor": "97add17f7dea48a88325",
+            "amount": 240
+        }
+    },
+    {
+        "collection": "donations",
+        "id": "c79a4484ecd04fa49b77",
+        "data": {
+            "campaign": "a45c093e8fbb4d8c8fce",
+            "donor": "acdfcf11079e49a6b6ae",
+            "amount": 250
+        }
+    },
+    {
+        "collection": "donations",
+        "id": "62f279d79f234a1488b0",
+        "data": {
+            "campaign": "b84da506508b4f52a6e6",
+            "donor": "99c5f8e943934a30bcd6",
+            "amount": 20
+        }
+    },
+    {
+        "collection": "donations",
+        "id": "7a6165fe3a4d42a68dde",
+        "data": {
+            "campaign": "135c1666d5d24698b418",
+            "donor": "8c338098ca07442598d1",
+            "amount": 40
+        }
+    },
+    {
+        "collection": "donations",
+        "id": "5455a6ff6b1f4b95813c",
+        "data": {
+            "campaign": "5c3d6313aae146c7b9db",
+            "donor": "1f3d7ba161e84f629a7c",
+            "amount": 90
+        }
+    },
+    {
+        "collection": "donations",
+        "id": "4d458ea6070442f2989b",
+        "data": {
+            "campaign": "135c1666d5d24698b418",
+            "donor": "368ee1c2bebd47c48a00",
+            "amount": 90
+        }
+    },
+    {
+        "collection": "donations",
+        "id": "a1e1c29db7c247b7b7ba",
+        "data": {
+            "campaign": "75f374577ab147578cbe",
+            "donor": "aae504e7d4ca4ff99fff",
+            "amount": 60
+        }
+    },
+    {
+        "collection": "donations",
+        "id": "cb94d912b0cd423eaff8",
+        "data": {
+            "campaign": "75f374577ab147578cbe",
+            "donor": "acdfcf11079e49a6b6ae",
+            "amount": 90
+        }
+    },
+    {
+        "collection": "donations",
+        "id": "aecf501561ce45ee83b2",
+        "data": {
+            "campaign": "a918e7def61d4ee689b5",
+            "donor": "1913dccf31104471b059",
+            "amount": 150
+        }
+    },
+    {
+        "collection": "donations",
+        "id": "24eafafb0b2a44ecb1f8",
+        "data": {
+            "campaign": "143b0c0bc68f4b56aff0",
+            "donor": "bd9682710f784951aad8",
+            "amount": 400
+        }
+    },
+    {
+        "collection": "donations",
+        "id": "2f874057fbe142f89b9b",
+        "data": {
+            "campaign": "b84da506508b4f52a6e6",
+            "donor": "3bc88014146348c49907",
+            "amount": 50
+        }
+    },
+    {
+        "collection": "donations",
+        "id": "8f1e0989e1db4f3588dd",
+        "data": {
+            "campaign": "a5b2b63d6ef44b37b993",
+            "donor": "58725a20335147a9b13b",
+            "amount": 350
+        }
+    },
+    {
+        "collection": "donations",
+        "id": "61f8daf9849e4d5584b3",
+        "data": {
+            "campaign": "de87b3b760224638a9c1",
+            "donor": "df7517f42b8b4a7d8b88",
+            "amount": 120
+        }
+    },
+    {
+        "collection": "donations",
+        "id": "739b8f4ba4bd46bb9e4c",
+        "data": {
+            "campaign": "f810d8cd19ba4d5eaf99",
+            "donor": "1cf6df6032804a2f8b1e",
+            "amount": 125
+        }
+    },
+    {
+        "collection": "donations",
+        "id": "43a2c4cf91d8498ba0ed",
+        "data": {
+            "campaign": "7bde773588794af09e4e",
+            "donor": "1d32d81f426c4d069674",
+            "amount": 180
+        }
+    },
+    {
+        "collection": "donations",
+        "id": "f87cdf80a8054830af9f",
+        "data": {
+            "campaign": "de87b3b760224638a9c1",
+            "donor": "147e68d8a97745be919f",
+            "amount": 225
+        }
+    },
+    {
+        "collection": "donations",
+        "id": "6f3f46ba0a5e4c45a235",
+        "data": {
+            "campaign": "bccd31cd6c264449b8fa",
+            "donor": "b7a2edb16f66415e9a79",
+            "amount": 210
+        }
+    },
+    {
+        "collection": "donations",
+        "id": "49f1b5446af84b3e9285",
+        "data": {
+            "campaign": "f45a23d495f247cd907a",
+            "donor": "97add17f7dea48a88325",
+            "amount": 300
+        }
+    },
+    {
+        "collection": "donations",
+        "id": "e04de9243d6043a1bc5d",
+        "data": {
+            "campaign": "7cc9ec1c70ac491799a3",
+            "donor": "98e196091a004c3496eb",
+            "amount": 90
+        }
+    },
+    {
+        "collection": "donations",
+        "id": "069b3ad810a54607bf8e",
+        "data": {
+            "campaign": "f1c4414d1fd74ab69969",
+            "donor": "25e6390f79e7496ba969",
+            "amount": 315
+        }
+    },
+    {
+        "collection": "donations",
+        "id": "3f97ee99075a4c42b0de",
+        "data": {
+            "campaign": "143b0c0bc68f4b56aff0",
+            "donor": "dbe31eb9c1364750abb8",
+            "amount": 60
+        }
+    },
+    {
+        "collection": "donations",
+        "id": "7ece507ddfd34e448757",
+        "data": {
+            "campaign": "f45a23d495f247cd907a",
+            "donor": "c8a5e4fc3c1942449044",
+            "amount": 135
+        }
+    },
+    {
+        "collection": "donations",
+        "id": "1032637ab31146a3959f",
+        "data": {
+            "campaign": "82d4f79423024eebab1e",
+            "donor": "d01a034a64f14ab2a87b",
+            "amount": 135
+        }
+    },
+    {
+        "collection": "donations",
+        "id": "f83f87910d314bea990c",
+        "data": {
+            "campaign": "aae62c8c38d047efa868",
+            "donor": "7c060ee9345a4978b079",
+            "amount": 270
+        }
+    },
+    {
+        "collection": "donations",
+        "id": "bef6dc3e808444e489a7",
+        "data": {
+            "campaign": "5c3d6313aae146c7b9db",
+            "donor": "f1b26825217f4fb8b46f",
+            "amount": 50
+        }
+    },
+    {
+        "collection": "donations",
+        "id": "a727069794454d358609",
+        "data": {
+            "campaign": "8811d0dff2504344a89b",
+            "donor": "80403302ad614b1e9004",
+            "amount": 175
+        }
+    },
+    {
+        "collection": "donations",
+        "id": "2d8c1e6cc396480aa124",
+        "data": {
+            "campaign": "46bc552cd9714b5ab9a1",
+            "donor": "b3bef33e6b874d6db86b",
+            "amount": 30
+        }
+    },
+    {
+        "collection": "donations",
+        "id": "810e27c4f74a4a708b96",
+        "data": {
+            "campaign": "1702615c336147219891",
+            "donor": "f8ccfeed8f0749ee93f3",
+            "amount": 105
+        }
+    },
+    {
+        "collection": "donations",
+        "id": "38ef2c74668344aead53",
+        "data": {
+            "campaign": "96bd5b61cba941f1b6cb",
+            "donor": "c8a5e4fc3c1942449044",
+            "amount": 270
+        }
+    },
+    {
+        "collection": "donations",
+        "id": "f73617a26f3247eca1ab",
+        "data": {
+            "campaign": "bae04507c523429fa045",
+            "donor": "913349c0d8e34dedaba7",
+            "amount": 45
+        }
+    },
+    {
+        "collection": "donations",
+        "id": "d1201cf74a7c43708ccc",
+        "data": {
+            "campaign": "95809499ae8a49f6a7db",
+            "donor": "1f3d7ba161e84f629a7c",
+            "amount": 160
+        }
+    },
+    {
+        "collection": "donations",
+        "id": "686716576e9f4b0d9f15",
+        "data": {
+            "campaign": "902110774a5146d08c96",
+            "donor": "25e6390f79e7496ba969",
+            "amount": 15
+        }
+    },
+    {
+        "collection": "donations",
+        "id": "406efb772bd143be9749",
+        "data": {
+            "campaign": "39bd8658cd754a7caae5",
+            "donor": "0ef76f1fc2134e98bd7d",
+            "amount": 30
+        }
+    },
+    {
+        "collection": "donations",
+        "id": "6c7c7e06eb7e472c9e88",
+        "data": {
+            "campaign": "a5b2b63d6ef44b37b993",
+            "donor": "7a6bf2bcddfd4ca3a19f",
+            "amount": 240
+        }
+    },
+    {
+        "collection": "donations",
+        "id": "087d26b5927846f89d10",
+        "data": {
+            "campaign": "1702615c336147219891",
+            "donor": "b33ef37d391d40b48180",
+            "amount": 100
+        }
+    },
+    {
+        "collection": "donations",
+        "id": "4444c4082aa14f7d8aa8",
+        "data": {
+            "campaign": "f1c4414d1fd74ab69969",
+            "donor": "acdfcf11079e49a6b6ae",
+            "amount": 100
+        }
+    },
+    {
+        "collection": "donations",
+        "id": "d902bfaaebf94d259646",
+        "data": {
+            "campaign": "f1c4414d1fd74ab69969",
+            "donor": "05143c3fe7974a6c801d",
+            "amount": 15
+        }
+    },
+    {
+        "collection": "donations",
+        "id": "c2c12f921d9549df8574",
+        "data": {
+            "campaign": "39bd8658cd754a7caae5",
+            "donor": "1913dccf31104471b059",
+            "amount": 5
+        }
+    },
+    {
+        "collection": "donations",
+        "id": "d3634e33d7084af28804",
+        "data": {
+            "campaign": "75f374577ab147578cbe",
+            "donor": "3e36ea20298c4563b28e",
+            "amount": 120
+        }
+    },
+    {
+        "collection": "donations",
+        "id": "e435e2eee21f463daf0d",
+        "data": {
+            "campaign": "135c1666d5d24698b418",
+            "donor": "7a1379e5ac8b42eba344",
+            "amount": 200
+        }
+    },
+    {
+        "collection": "donations",
+        "id": "a952381258894e679365",
+        "data": {
+            "campaign": "b84da506508b4f52a6e6",
+            "donor": "e935a252c9eb47c783b3",
+            "amount": 50
+        }
+    },
+    {
+        "collection": "donations",
+        "id": "1764ae0b250447ae8e1e",
+        "data": {
+            "campaign": "b84da506508b4f52a6e6",
+            "donor": "953a5d82695b4432ba3b",
+            "amount": 80
+        }
+    },
+    {
+        "collection": "donations",
+        "id": "7498f14b9ef840f99913",
+        "data": {
+            "campaign": "a918e7def61d4ee689b5",
+            "donor": "6999cb0936fb4ec8b82e",
+            "amount": 60
+        }
+    },
+    {
+        "collection": "donations",
+        "id": "ee041618333c4895bb94",
+        "data": {
+            "campaign": "f1c4414d1fd74ab69969",
+            "donor": "3f6f588a10ca4999a01d",
+            "amount": 160
+        }
+    },
+    {
+        "collection": "donations",
+        "id": "959f1ed43ea34d31805c",
+        "data": {
+            "campaign": "bae04507c523429fa045",
+            "donor": "b33ef37d391d40b48180",
+            "amount": 40
+        }
+    },
+    {
+        "collection": "donations",
+        "id": "6e9f0a2dbef64300be43",
+        "data": {
+            "campaign": "676160f83935418d8aff",
+            "donor": "52c982a47cac4fcaa816",
+            "amount": 360
+        }
+    },
+    {
+        "collection": "donations",
+        "id": "a42233f21e8c44d0bb51",
+        "data": {
+            "campaign": "75f374577ab147578cbe",
+            "donor": "270dfe407cd24de1a53f",
+            "amount": 90
+        }
+    },
+    {
+        "collection": "donations",
+        "id": "84bdf117de1d4080821e",
+        "data": {
+            "campaign": "143b0c0bc68f4b56aff0",
+            "donor": "cc9f4b1da9154c4488d6",
+            "amount": 175
+        }
+    },
+    {
+        "collection": "donations",
+        "id": "2dedb5524b814dc29e30",
+        "data": {
+            "campaign": "82d4f79423024eebab1e",
+            "donor": "b1e1813bbda5495f8742",
+            "amount": 25
+        }
+    },
+    {
+        "collection": "donations",
+        "id": "557bf396eacc4b88aee6",
+        "data": {
+            "campaign": "a2fad786f66e4405b3cc",
+            "donor": "b3bef33e6b874d6db86b",
+            "amount": 500
+        }
+    },
+    {
+        "collection": "donations",
+        "id": "36e45262f0ae4ce4a895",
+        "data": {
+            "campaign": "676160f83935418d8aff",
+            "donor": "3bc88014146348c49907",
+            "amount": 25
+        }
+    },
+    {
+        "collection": "donations",
+        "id": "6e169e910d834890a52e",
+        "data": {
+            "campaign": "46bc552cd9714b5ab9a1",
+            "donor": "913349c0d8e34dedaba7",
+            "amount": 35
+        }
+    },
+    {
+        "collection": "donations",
+        "id": "eef3d810939f483bb0c0",
+        "data": {
+            "campaign": "82d4f79423024eebab1e",
+            "donor": "80403302ad614b1e9004",
+            "amount": 20
+        }
+    },
+    {
+        "collection": "donations",
+        "id": "4b2778d5fb6345648507",
+        "data": {
+            "campaign": "f810d8cd19ba4d5eaf99",
+            "donor": "b33ef37d391d40b48180",
+            "amount": 320
+        }
+    },
+    {
+        "collection": "donations",
+        "id": "c2abca4a4cb94ad99d7d",
+        "data": {
+            "campaign": "19c0749c97b44616b60e",
+            "donor": "cc9f4b1da9154c4488d6",
+            "amount": 240
+        }
+    },
+    {
+        "collection": "donations",
+        "id": "e08674ee0aff499883f6",
+        "data": {
+            "campaign": "adf53a3c16cc470bbf03",
+            "donor": "3f6f588a10ca4999a01d",
+            "amount": 300
+        }
+    },
+    {
+        "collection": "donations",
+        "id": "0a835dd939354a29a636",
+        "data": {
+            "campaign": "5c3d6313aae146c7b9db",
+            "donor": "1e5de2b9ad5d418898b2",
+            "amount": 50
+        }
+    },
+    {
+        "collection": "donations",
+        "id": "2407539dcfd747e8ae40",
+        "data": {
+            "campaign": "c3b77518432a48d1ac0b",
+            "donor": "290a5fb7059f4a2abb4d",
+            "amount": 280
+        }
+    },
+    {
+        "collection": "donations",
+        "id": "ea4fa3d3a15d4b32a1fe",
+        "data": {
+            "campaign": "a87f8a72934749d9bbb8",
+            "donor": "a66bf1574f8744fd988a",
+            "amount": 150
+        }
+    },
+    {
+        "collection": "donations",
+        "id": "56d3d9fa557c4672bf37",
+        "data": {
+            "campaign": "a87f8a72934749d9bbb8",
+            "donor": "953a5d82695b4432ba3b",
+            "amount": 350
+        }
+    },
+    {
+        "collection": "donations",
+        "id": "4503763ccc6f4714a9ee",
+        "data": {
+            "campaign": "e644ffc13e45476ab476",
+            "donor": "3fa976e7527841a683c4",
+            "amount": 500
+        }
+    },
+    {
+        "collection": "donations",
+        "id": "ca50320481854c11a058",
+        "data": {
+            "campaign": "b9c219c4a3f5498d96e2",
+            "donor": "687fc5ff6f5a42f1bf59",
+            "amount": 50
+        }
+    },
+    {
+        "collection": "donations",
+        "id": "7759d88bbe3840ce885d",
+        "data": {
+            "campaign": "14cc3949063f48f696c4",
+            "donor": "72b4ace8e6354e1086bd",
+            "amount": 60
+        }
+    },
+    {
+        "collection": "donations",
+        "id": "fe4fed6f450745d0804e",
+        "data": {
+            "campaign": "59d32e9805fc4d3388db",
+            "donor": "b0703a8917ae4983b5e2",
+            "amount": 450
+        }
+    },
+    {
+        "collection": "donations",
+        "id": "61f0993481f245ff931f",
+        "data": {
+            "campaign": "c3b77518432a48d1ac0b",
+            "donor": "7e2d40bce50248faa2b4",
+            "amount": 135
+        }
+    },
+    {
+        "collection": "donations",
+        "id": "dc346c4b3dca47129f3d",
+        "data": {
+            "campaign": "f810d8cd19ba4d5eaf99",
+            "donor": "844d9e35d64c4409ba64",
+            "amount": 175
+        }
+    },
+    {
+        "collection": "donations",
+        "id": "e75a1691fdb14c028d8c",
+        "data": {
+            "campaign": "902110774a5146d08c96",
+            "donor": "44d5984f5c7340c09d06",
+            "amount": 210
+        }
+    },
+    {
+        "collection": "donations",
+        "id": "6ff9cdf244fc4021b565",
+        "data": {
+            "campaign": "826a7006c3d34ff9b65a",
+            "donor": "25e6390f79e7496ba969",
+            "amount": 450
+        }
+    },
+    {
+        "collection": "donations",
+        "id": "00f12b60ba35489f902f",
+        "data": {
+            "campaign": "d9acf2caa90d45f2bcef",
+            "donor": "078ba4bfce324ced8586",
+            "amount": 80
+        }
+    },
+    {
+        "collection": "donations",
+        "id": "112549acaae04790a2ec",
+        "data": {
+            "campaign": "bccd31cd6c264449b8fa",
+            "donor": "f1b26825217f4fb8b46f",
+            "amount": 15
+        }
+    },
+    {
+        "collection": "donations",
+        "id": "07548845fa084605bcc5",
+        "data": {
+            "campaign": "82d4f79423024eebab1e",
+            "donor": "f7723afa140f40ff9e70",
+            "amount": 210
+        }
+    },
+    {
+        "collection": "donations",
+        "id": "c1849e70dfdc4ad8b4b6",
+        "data": {
+            "campaign": "39bd8658cd754a7caae5",
+            "donor": "c38ee984164746879a0f",
+            "amount": 280
+        }
+    },
+    {
+        "collection": "donations",
+        "id": "3a38b763388f4b3aafe0",
+        "data": {
+            "campaign": "50d463d2c06440a186c9",
+            "donor": "f1b26825217f4fb8b46f",
+            "amount": 10
+        }
+    },
+    {
+        "collection": "donations",
+        "id": "88e7270852ee445f9480",
+        "data": {
+            "campaign": "d862f4a1e42e4ed7a01c",
+            "donor": "b0703a8917ae4983b5e2",
+            "amount": 75
+        }
+    },
+    {
+        "collection": "donations",
+        "id": "e6140782db6942dd86f5",
+        "data": {
+            "campaign": "6747c2d7631d4763b1e6",
+            "donor": "d78e085ef27f4b9082fe",
+            "amount": 100
+        }
+    },
+    {
+        "collection": "donations",
+        "id": "e291dd7c776643b3ae0f",
+        "data": {
+            "campaign": "96bd5b61cba941f1b6cb",
+            "donor": "57d62f566516411e98eb",
+            "amount": 10
+        }
+    },
+    {
+        "collection": "donations",
+        "id": "0539e22eda944d09bdb0",
+        "data": {
+            "campaign": "1702615c336147219891",
+            "donor": "b3bef33e6b874d6db86b",
+            "amount": 20
+        }
+    }
+]

--- a/terraform/modules/emblem-app/firestore.tf
+++ b/terraform/modules/emblem-app/firestore.tf
@@ -1,6 +1,7 @@
 locals {
   donor_test_data    = jsondecode(file("${path.module}/files/test-data/donors.json"))
   campaign_test_data = jsondecode(file("${path.module}/files/test-data/campaigns.json"))
+  cause_test_data = jsondecode(file("${path.module}/files/test-data/causes.json"))
 }
 
 # Seed Firestore with approvers
@@ -71,4 +72,25 @@ resource "google_firestore_document" "campaigns" {
   collection  = "campaigns"
   document_id = local.campaign_test_data[count.index].id
   fields      = data.template_file.campaigns[count.index].rendered
+}
+
+# Seed test data to causes collection
+
+data "template_file" "causes" {
+  template = file("${path.module}/files/templates/causes.tftpl")
+  count    = var.seed_test_data ? "${length(local.cause_test_data)}" : 0
+  vars = {
+    name        = local.cause_test_data[count.index].data.name
+    description = local.cause_test_data[count.index].data.description
+    imageUrl    = local.cause_test_data[count.index].data.imageUrl
+    active      = local.cause_test_data[count.index].data.active
+  }
+}
+
+resource "google_firestore_document" "causes" {
+  project     = var.project_id
+  count       = var.seed_test_data ? "${length(data.template_file.causes)}" : 0
+  collection  = "causes"
+  document_id = local.cause_test_data[count.index].id
+  fields      = data.template_file.causes[count.index].rendered
 }

--- a/terraform/modules/emblem-app/firestore.tf
+++ b/terraform/modules/emblem-app/firestore.tf
@@ -1,7 +1,8 @@
 locals {
   donor_test_data    = jsondecode(file("${path.module}/files/test-data/donors.json"))
   campaign_test_data = jsondecode(file("${path.module}/files/test-data/campaigns.json"))
-  cause_test_data = jsondecode(file("${path.module}/files/test-data/causes.json"))
+  cause_test_data    = jsondecode(file("${path.module}/files/test-data/causes.json"))
+  donation_test_data = jsondecode(file("${path.module}/files/test-data/donations.json"))  
 }
 
 # Seed Firestore with approvers
@@ -93,4 +94,24 @@ resource "google_firestore_document" "causes" {
   collection  = "causes"
   document_id = local.cause_test_data[count.index].id
   fields      = data.template_file.causes[count.index].rendered
+}
+
+# Seed test data to donations collection
+
+data "template_file" "donations" {
+  template = file("${path.module}/files/templates/donations.tftpl")
+  count    = var.seed_test_data ? "${length(local.donation_test_data)}" : 0
+  vars = {
+    campaign        = local.donation_test_data[count.index].data.campaign
+    donor = local.donation_test_data[count.index].data.donor
+    amount    = local.donation_test_data[count.index].data.amount
+  }
+}
+
+resource "google_firestore_document" "donations" {
+  project     = var.project_id
+  count       = var.seed_test_data ? "${length(data.template_file.donations)}" : 0
+  collection  = "donations"
+  document_id = local.donation_test_data[count.index].id
+  fields      = data.template_file.donations[count.index].rendered
 }

--- a/terraform/modules/emblem-app/firestore.tf
+++ b/terraform/modules/emblem-app/firestore.tf
@@ -2,7 +2,7 @@ locals {
   donor_test_data    = jsondecode(file("${path.module}/files/test-data/donors.json"))
   campaign_test_data = jsondecode(file("${path.module}/files/test-data/campaigns.json"))
   cause_test_data    = jsondecode(file("${path.module}/files/test-data/causes.json"))
-  donation_test_data = jsondecode(file("${path.module}/files/test-data/donations.json"))  
+  donation_test_data = jsondecode(file("${path.module}/files/test-data/donations.json"))
 }
 
 # Seed Firestore with approvers
@@ -102,9 +102,9 @@ data "template_file" "donations" {
   template = file("${path.module}/files/templates/donations.tftpl")
   count    = var.seed_test_data ? "${length(local.donation_test_data)}" : 0
   vars = {
-    campaign        = local.donation_test_data[count.index].data.campaign
-    donor = local.donation_test_data[count.index].data.donor
-    amount    = local.donation_test_data[count.index].data.amount
+    campaign = local.donation_test_data[count.index].data.campaign
+    donor    = local.donation_test_data[count.index].data.donor
+    amount   = local.donation_test_data[count.index].data.amount
   }
 }
 


### PR DESCRIPTION
Related to #644 

This adds the following to the emblem-app terraform module:
- a Firestore document resource for each object in a `causes.json` file
- a Firestore document resource for each object in a `donations.json` file

The above uses Terraform templates and json files made up from data in [sample_data.json](https://github.com/GoogleCloudPlatform/emblem/blob/main/content-api/data/sample_data.json)

Note: merging this PR will not change any Terraform functionality. The `seed_test_data` variable used is set to `false` by default so that none of the resources associated with test data is added. The resources in this module will remain dormant until `seed_test_data` is set to `true`

This will only partially address #602 

Forthcoming PR will integrate these features with `setup.sh`