### PR TITLE
fix: update context in api-build.cloudbuild.yaml

### DIFF
--- a/ops/api-build.cloudbuild.yaml
+++ b/ops/api-build.cloudbuild.yaml
@@ -20,7 +20,7 @@ steps:
       - 'build'
       - '-t'
       - '${_REGION}-docker.pkg.dev/${PROJECT_ID}/content-api/content-api:${_SHORT_SHA}'
-      - '.'
+      - 'content-api/.'
 
 # Default to us-central1
 substitutions:


### PR DESCRIPTION
**Issue:** This resolved dockerfile not found errors when api-push-to-main trigger

<img width="906" alt="Screen Shot 2022-09-20 at 10 58 16 AM" src="https://user-images.githubusercontent.com/1331216/191331533-44e067a8-dcb2-4db8-830c-f929f9476291.png">

**To recreate the bug:**
 - **Required:** You should have a full working setup of Emblem already in CloudShell or locally
 - Head to the `content-api/` folder
 - Update anything within this folder (`api-push-to-main` executes on any file updates in `content-api/`)
 - Head over to the history tab in `https://console.cloud.google.com/cloud-build/builds` and monitor the trigger
 - You should see a build failure rather quickly and a similar log as above

