### PR TITLE
fix: decoupling triggers when an edit is made within e2e-test/

### DIFF
--- a/docs/testing.md
+++ b/docs/testing.md
@@ -23,8 +23,8 @@ The [Website](/docs/website.md) component is covered by automatic **End-to-End (
 These tests run the website in a [Docker container](/ops/e2e-runner), and check that the website's routes load without any errors.
 
 These tests run automatically under two circumstances:
-* [nightly against `main`](/terraform/ops/triggers/cloud_build_triggers.tf#:~:text=e2e_runner_nightly_build_trigger)
-* [when the `main` branch is updated](/terraform/ops/triggers/cloud_build_triggers.tf#:~:text=e2e_runner_push_to_main_build_trigger).
+* [nightly against `main`](/terraform/ops/testing.tf#:~:text=e2e_nightly_tests)
+* [when the `main` branch is updated](/terraform/modules/ops/build.tf#:~:text=e2e_testing_build_runner).
 
 > **Note:** we are working on adding a pull-request runner as well
 

--- a/terraform/modules/ops/build.tf
+++ b/terraform/modules/ops/build.tf
@@ -34,6 +34,9 @@ resource "google_cloudbuild_trigger" "web_push_to_main" {
     "website/*/*",
     "client-libs/python/*"
   ]
+  ignore_files = [
+    "website/e2e-test/*",
+  ]
   github {
     owner = var.repo_owner
     name  = var.repo_name
@@ -58,7 +61,7 @@ resource "google_cloudbuild_trigger" "e2e_testing_build_runner" {
   name     = "e2e-runner-push-to-main"
   filename = "ops/e2e-runner-build.cloudbuild.yaml"
   included_files = [
-    "website/e2e-test/Dockerfile",
+    "website/e2e-test/*",
   ]
   github {
     owner = var.repo_owner


### PR DESCRIPTION
**Issues:**
*  Removing outdated reference to `website/e2e-test/Dockerfile` (since moved to `ops/e2e-runner/`)
* Both `e2e-runner-push-to-main` and `web-push-to-main` (and thus the full web delivery) gets executed if an edit is made to `website/e2e-test/`
* Fixes broken links describing e2e push to main and e2e nightly testing

**Fixes:**
* Ensures that any edits to `e2e-tests/` within `website/` only executes `e2e-runner-push-to-main` 
* Links should reference correct Tf samples referencing e2e testing