### PR TITLE
fix: resolves api_unit_test token creation + datastore permissions issues

### DIFF
--- a/terraform/modules/ops/main.tf
+++ b/terraform/modules/ops/main.tf
@@ -22,6 +22,18 @@ resource "google_project_iam_member" "pubsub_publisher_iam_member" {
     google_project_service.emblem_ops_services
   ]
 }
+  
+resource "google_project_iam_member" "test_cloudbuild_iam_member" {
+  project  = var.project_id
+  provider = google
+  count = length(var.testRolesList)
+  role =  var.rolesList[count.index]
+  member   = "serviceAccount:${data.google_project.target_project.number}@cloudbuild.gserviceaccount.com"
+
+  depends_on = [
+    google_project_service.emblem_ops_services
+  ]
+}
 
 #####################
 # Container Hosting #

--- a/terraform/modules/ops/main.tf
+++ b/terraform/modules/ops/main.tf
@@ -15,8 +15,8 @@ resource "google_pubsub_topic" "gcr" {
 resource "google_project_iam_member" "pubsub_publisher_iam_member" {
   project  = var.project_id
   provider = google
-  count = length(var.pubsub_iam_roles_list)
-  role =  var.pubsub_iam_roles_list[count.index]
+  for_each = toset(local.pubsub_iam_roles_list)
+  role =  each.key
   member   = "serviceAccount:${data.google_project.target_project.number}@cloudbuild.gserviceaccount.com"
 
   depends_on = [

--- a/terraform/modules/ops/main.tf
+++ b/terraform/modules/ops/main.tf
@@ -2,6 +2,15 @@ data "google_project" "target_project" {
   project_id = var.project_id
 }
 
+locals {
+  # Cloud build service account roles
+  pubsub_iam_roles_list = [
+    "roles/pubsub.publisher",
+    "roles/datastore.user",
+    "roles/iam.serviceAccountTokenCreator"
+  ]
+}
+
 # Create this topic to emit writes to Artifact Registry as events.
 # https://cloud.google.com/artifact-registry/docs/configure-notifications#topic
 resource "google_pubsub_topic" "gcr" {

--- a/terraform/modules/ops/main.tf
+++ b/terraform/modules/ops/main.tf
@@ -15,19 +15,8 @@ resource "google_pubsub_topic" "gcr" {
 resource "google_project_iam_member" "pubsub_publisher_iam_member" {
   project  = var.project_id
   provider = google
-  role     = "roles/pubsub.publisher"
-  member   = "serviceAccount:${data.google_project.target_project.number}@cloudbuild.gserviceaccount.com"
-
-  depends_on = [
-    google_project_service.emblem_ops_services
-  ]
-}
-  
-resource "google_project_iam_member" "test_cloudbuild_iam_member" {
-  project  = var.project_id
-  provider = google
-  count = length(var.testRolesList)
-  role =  var.rolesList[count.index]
+  count = length(var.pubsub_iam_roles_list)
+  role =  var.pubsub_iam_roles_list[count.index]
   member   = "serviceAccount:${data.google_project.target_project.number}@cloudbuild.gserviceaccount.com"
 
   depends_on = [

--- a/terraform/modules/ops/main.tf
+++ b/terraform/modules/ops/main.tf
@@ -16,7 +16,7 @@ resource "google_project_iam_member" "pubsub_publisher_iam_member" {
   project  = var.project_id
   provider = google
   for_each = toset(local.pubsub_iam_roles_list)
-  role =  each.key
+  role     = each.key
   member   = "serviceAccount:${data.google_project.target_project.number}@cloudbuild.gserviceaccount.com"
 
   depends_on = [

--- a/terraform/modules/ops/services.tf
+++ b/terraform/modules/ops/services.tf
@@ -11,6 +11,12 @@ locals {
   beta_services = var.enable_apis ? [
     "artifactregistry.googleapis.com"
   ] : []
+  # Cloud build service account roles
+  pubsub_iam_roles_list = [
+    "roles/pubsub.publisher",
+    "roles/datastore.user",
+    "roles/iam.serviceAccountTokenCreator"
+  ]
 }
 
 resource "google_project_service" "emblem_ops_services" {

--- a/terraform/modules/ops/services.tf
+++ b/terraform/modules/ops/services.tf
@@ -11,12 +11,6 @@ locals {
   beta_services = var.enable_apis ? [
     "artifactregistry.googleapis.com"
   ] : []
-  # Cloud build service account roles
-  pubsub_iam_roles_list = [
-    "roles/pubsub.publisher",
-    "roles/datastore.user",
-    "roles/iam.serviceAccountTokenCreator"
-  ]
 }
 
 resource "google_project_service" "emblem_ops_services" {

--- a/terraform/modules/ops/testing.tf
+++ b/terraform/modules/ops/testing.tf
@@ -9,7 +9,6 @@ resource "google_service_account" "test_user" {
   account_id   = "test-user"
   display_name = "Test Account [User]"
   description  = "Mock user account for unit and integration tests."
-
 }
 
 resource "google_service_account" "test_approver" {

--- a/terraform/modules/ops/variables.tf
+++ b/terraform/modules/ops/variables.tf
@@ -33,7 +33,7 @@ variable "setup_cd_system" {
   description = "Create deployment triggers. Enable only if Cloud Build has been granted GitHub access."
 }
 
-variable "testRolesList" {
+variable "pubsub_iam_roles_list" {
   type = list(string)
-  default = ["roles/datastore.user", "roles/iam.serviceAccountTokenCreator"]
+  default = ["roles/pubsub.publisher", "roles/datastore.user", "roles/iam.serviceAccountTokenCreator"]
 }

--- a/terraform/modules/ops/variables.tf
+++ b/terraform/modules/ops/variables.tf
@@ -32,8 +32,3 @@ variable "setup_cd_system" {
   default     = false
   description = "Create deployment triggers. Enable only if Cloud Build has been granted GitHub access."
 }
-
-variable "pubsub_iam_roles_list" {
-  type = list(string)
-  default = ["roles/pubsub.publisher", "roles/datastore.user", "roles/iam.serviceAccountTokenCreator"]
-}

--- a/terraform/modules/ops/variables.tf
+++ b/terraform/modules/ops/variables.tf
@@ -33,3 +33,7 @@ variable "setup_cd_system" {
   description = "Create deployment triggers. Enable only if Cloud Build has been granted GitHub access."
 }
 
+variable "testRolesList" {
+  type = list(string)
+  default = ["roles/datastore.user", "roles/iam.serviceAccountTokenCreator"]
+}


### PR DESCRIPTION
**Issue:** 
Resolves token retrieval error in `unit-tests.cloudbuild.yaml`. The curl fetch for new generated id token was throwing 
```
{'error': {'code': 403, 'message': 'The caller does not have permission', 'status': 'PERMISSION_DENIED'}}
```
permissions error due to the `cloudbuild` service account not given the correct roles.

**To recreate bug:**
 -  **Required:** You should have a working full setup of Emblem already
 - Create a new branch. Make any small change and create a pull request to trigger `api-unit-tests`. 
 - You should a series of errors related to firestore database and permissions errors.

**Fixes:**
 - Adding `roles/datastore.user` (firestore), `roles/iam.serviceAccountTokenCreator` roles to cloudbuild service account
