### PR TITLE
fix: adds in _CONTEXT substitution for api-build.cloudbuild.yaml

### DIFF
--- a/ops/api-build.cloudbuild.yaml
+++ b/ops/api-build.cloudbuild.yaml
@@ -20,7 +20,7 @@ steps:
       - 'build'
       - '-t'
       - '${_REGION}-docker.pkg.dev/${PROJECT_ID}/content-api/content-api:${_SHORT_SHA}'
-      - 'content-api/.'
+      - '${_CONTEXT}'
 
 # Default to us-central1
 substitutions:

--- a/setup.sh
+++ b/setup.sh
@@ -147,7 +147,7 @@ echo
 
 gcloud builds submit "content-api" \
     --config=ops/api-build.cloudbuild.yaml \
-    --project="$OPS_PROJECT" --substitutions=_REGION="$REGION",_SHORT_SHA="$SHORT_SHA"
+    --project="$OPS_PROJECT" --substitutions=_REGION="$REGION",_SHORT_SHA="$SHORT_SHA",_CONTEXT="."
 
 gcloud builds submit \
     --config=ops/web-build.cloudbuild.yaml \

--- a/terraform/modules/ops/build.tf
+++ b/terraform/modules/ops/build.tf
@@ -20,8 +20,10 @@ resource "google_cloudbuild_trigger" "api_push_to_main" {
   # These properties are detected as changed if not initialized.
   # Alternately, add a lifecycle rule to ignore_changes.
   ignored_files = []
-  substitutions = {}
-  tags          = []
+  substitutions = {
+    _CONTEXT = "content-api/."
+  }
+  tags = []
 }
 
 resource "google_cloudbuild_trigger" "web_push_to_main" {
@@ -34,7 +36,7 @@ resource "google_cloudbuild_trigger" "web_push_to_main" {
     "website/*/*",
     "client-libs/python/*"
   ]
-  ignore_files = [
+  ignored_files = [
     "website/e2e-test/*",
   ]
   github {
@@ -50,7 +52,6 @@ resource "google_cloudbuild_trigger" "web_push_to_main" {
 
   # These properties are detected as changed if not initialized.
   # Alternately, add a lifecycle rule to ignore_changes.
-  ignored_files = []
   substitutions = {}
   tags          = []
 }


### PR DESCRIPTION
**Issue:** Setting correct context for wherever `api-build.cloudbuild.yaml` is called.
Also fixes misspelled property `ignored_files` for web build trigger in terraform.

**To recreate bug:**
 - **Required:** You will need to run the setup script in a clean project.
 - Execute `sh setup.sh`
 - Allow the setup script to flit through and you will eventually see the error below. Re-test to ensure that this fix can be run on initial setup AND when changes are introduced in `content-api/`

<img width="1172" alt="Screen Shot 2022-09-22 at 4 27 56 PM" src="https://user-images.githubusercontent.com/1331216/191868517-b2f324f4-a4fe-431c-b656-0b7e6c81bf63.png">
