### PR TITLE
fix: _SHORT_SHA variable usage

### DIFF
--- a/ops/api-build.cloudbuild.yaml
+++ b/ops/api-build.cloudbuild.yaml
@@ -19,14 +19,14 @@ steps:
     args: 
       - 'build'
       - '-t'
-      - '${_REGION}-docker.pkg.dev/${PROJECT_ID}/content-api/content-api:${_SHORT_SHA}'
+      - '${_REGION}-docker.pkg.dev/${PROJECT_ID}/content-api/content-api:${_IMAGE_TAG}'
       - '${_CONTEXT}'
 
 # Default to us-central1
 substitutions:
   _REGION: us-central1
-  _SHORT_SHA: latest
+  _IMAGE_TAG: $SHORT_SHA
 
 # Store in Artifact Registry
 images:
-  - '${_REGION}-docker.pkg.dev/${PROJECT_ID}/content-api/content-api:${_SHORT_SHA}'
+  - '${_REGION}-docker.pkg.dev/${PROJECT_ID}/content-api/content-api:${_IMAGE_TAG}'

--- a/ops/web-build.cloudbuild.yaml
+++ b/ops/web-build.cloudbuild.yaml
@@ -23,14 +23,14 @@ steps:
       - |
         cp -R client-libs/ website/client-libs
         docker build -t \
-        ${_REGION}-docker.pkg.dev/${PROJECT_ID}/website/website:${_SHORT_SHA} \
+        ${_REGION}-docker.pkg.dev/${PROJECT_ID}/website/website:${_IMAGE_TAG} \
         website/. 
 
 # Default to us-central1 
 substitutions:
   _REGION: us-central1
-  _SHORT_SHA: latest
+  _IMAGE_TAG: $SHORT_SHA
 
 # Store in Artifact Registry
 images:
-  - '${_REGION}-docker.pkg.dev/${PROJECT_ID}/website/website:${_SHORT_SHA}'
+  - '${_REGION}-docker.pkg.dev/${PROJECT_ID}/website/website:${_IMAGE_TAG}'

--- a/setup.sh
+++ b/setup.sh
@@ -136,7 +136,7 @@ fi # skip seeding
 # Build Containers #
 ####################
 
-SHORT_SHA="setup"
+SETUP_IMAGE_TAG="setup"
 E2E_RUNNER_TAG="latest"
 
 if [[ -z "$SKIP_BUILD" ]]; then
@@ -147,12 +147,12 @@ echo
 
 gcloud builds submit "content-api" \
     --config=ops/api-build.cloudbuild.yaml \
-    --project="$OPS_PROJECT" --substitutions=_REGION="$REGION",_SHORT_SHA="$SHORT_SHA",_CONTEXT="."
+    --project="$OPS_PROJECT" --substitutions=_REGION="$REGION",_IMAGE_TAG="$SETUP_IMAGE_TAG",_CONTEXT="."
 
 gcloud builds submit \
     --config=ops/web-build.cloudbuild.yaml \
     --ignore-file=ops/web-build.gcloudignore \
-    --project="$OPS_PROJECT" --substitutions=_REGION="$REGION",_SHORT_SHA="$SHORT_SHA"
+    --project="$OPS_PROJECT" --substitutions=_REGION="$REGION",_IMAGE_TAG="$SETUP_IMAGE_TAG"
 
 gcloud builds submit "ops/e2e-runner" \
     --config=ops/e2e-runner-build.cloudbuild.yaml \
@@ -175,7 +175,7 @@ if [[ -z "$SKIP_DEPLOY" ]]; then
 
     gcloud run deploy content-api \
         --allow-unauthenticated \
-        --image "${REGION}-docker.pkg.dev/${OPS_PROJECT}/content-api/content-api:${SHORT_SHA}" \
+        --image "${REGION}-docker.pkg.dev/${OPS_PROJECT}/content-api/content-api:${SETUP_IMAGE_TAG}" \
         --service-account "api-manager@${STAGE_PROJECT}.iam.gserviceaccount.com" \
         --project "${STAGE_PROJECT}" \
         --region "${REGION}"
@@ -183,7 +183,7 @@ if [[ -z "$SKIP_DEPLOY" ]]; then
     STAGING_API_URL=$(gcloud run services describe content-api --project "${STAGE_PROJECT}" --region ${REGION} --format 'value(status.url)')
     gcloud run deploy website \
         --allow-unauthenticated \
-        --image "${REGION}-docker.pkg.dev/${OPS_PROJECT}/website/website:${SHORT_SHA}" \
+        --image "${REGION}-docker.pkg.dev/${OPS_PROJECT}/website/website:${SETUP_IMAGE_TAG}" \
         --service-account "website-manager@${STAGE_PROJECT}.iam.gserviceaccount.com" \
         --update-env-vars "EMBLEM_SESSION_BUCKET=${STAGE_PROJECT}-sessions" \
         --update-env-vars "EMBLEM_API_URL=${STAGING_API_URL}" \
@@ -197,7 +197,7 @@ if [[ -z "$SKIP_DEPLOY" ]]; then
     if [ "${PROD_PROJECT}" != "${STAGE_PROJECT}" ]; then
         gcloud run deploy content-api \
             --allow-unauthenticated \
-            --image "${REGION}-docker.pkg.dev/${OPS_PROJECT}/content-api/content-api:${SHORT_SHA}" \
+            --image "${REGION}-docker.pkg.dev/${OPS_PROJECT}/content-api/content-api:${SETUP_IMAGE_TAG}" \
             --service-account "api-manager@${PROD_PROJECT}.iam.gserviceaccount.com" \
             --project "${PROD_PROJECT}" \
             --region "${REGION}"
@@ -205,7 +205,7 @@ if [[ -z "$SKIP_DEPLOY" ]]; then
         PROD_API_URL=$(gcloud run services describe content-api --project "${PROD_PROJECT}" --region ${REGION} --format 'value(status.url)')
         gcloud run deploy website \
             --allow-unauthenticated \
-            --image "${REGION}-docker.pkg.dev/${OPS_PROJECT}/website/website:${SHORT_SHA}" \
+            --image "${REGION}-docker.pkg.dev/${OPS_PROJECT}/website/website:${SETUP_IMAGE_TAG}" \
             --service-account "website-manager@${PROD_PROJECT}.iam.gserviceaccount.com" \
             --update-env-vars "EMBLEM_SESSION_BUCKET=${PROD_PROJECT}-sessions" \
             --update-env-vars "EMBLEM_API_URL=${PROD_API_URL}" \


### PR DESCRIPTION
This PR:
- Replaces `$_SHORT_SHA` variable in api and website cloud build yaml files with `$_IMAGE_TAG`
- Adds  built-in`$SHORT_SHA` as default value in api and website cloud build yaml files
- Replaces `$SHORT_SHA` variable in `setup.sh` with `$SETUP_IMAGE_TAG`


To test:
- Run `setup.sh` from this branch (or just the build and run commands on lines 139 - 192)
- Trigger `api-deploy-to-main` and `web-deploy-to-main` build triggers using repo with this branch's changes.

Result:
- Builds from `setup.sh` will be tagged as `setup` in artifact registry.
- Builds from triggers will be tagged with short commit sha in artifact registry

Fixes #667 