### PR TITLE
fix: seed Firestore via build job

### DIFF
--- a/content-api/data/cloudbuild.yaml
+++ b/content-api/data/cloudbuild.yaml
@@ -1,0 +1,17 @@
+steps:
+  - id: Install Python requirements
+    name: python
+    entrypoint: pip
+    args: ["install", "-r", "requirements.txt", "--user"]
+  - id: Seed initial approver email
+    name: python
+    entrypoint: python
+    args: ["seed_test_approver.py", "${_APPROVER_EMAIL}"]
+    env:
+    - "GOOGLE_CLOUD_PROJECT=$_FIREBASE_PROJECT"
+  - id: Seed test user data
+    name: python
+    entrypoint: python
+    args: ["seed_database.py"]
+    env:
+    - "GOOGLE_CLOUD_PROJECT=$_FIREBASE_PROJECT"

--- a/content-api/data/requirements.txt
+++ b/content-api/data/requirements.txt
@@ -1,1 +1,1 @@
-firebase-admin==5.4.0
+google-cloud-firestore==2.7.0

--- a/content-api/data/requirements.txt
+++ b/content-api/data/requirements.txt
@@ -1,0 +1,1 @@
+firebase-admin==5.4.0

--- a/setup.sh
+++ b/setup.sh
@@ -122,12 +122,12 @@ if [[ -z "$SKIP_SEEDING" ]]; then
     fi
     approver="${approver:-$account}"
 
-    gcloud builds submit content-api/data  \
+    gcloud builds submit content-api/data  --project="$OPS_PROJECT" \
     --substitutions=_FIREBASE_PROJECT="${STAGE_PROJECT}",_APPROVER_EMAIL="${approver}" \
     --config=./content-api/data/cloudbuild.yaml
 
     if [ "${PROD_PROJECT}" != "${STAGE_PROJECT}" ]; then
-        gcloud builds submit content-api/data  \
+        gcloud builds submit content-api/data  --project="$OPS_PROJECT" \
         --substitutions=_FIREBASE_PROJECT="${PROD_PROJECT}",_APPROVER_EMAIL="${approver}" \
         --config=./content-api/data/cloudbuild.yaml
     fi

--- a/setup.sh
+++ b/setup.sh
@@ -116,20 +116,21 @@ if [[ -z "$SKIP_SEEDING" ]]; then
     echo "$(tput bold)Seeding default content...$(tput sgr0)"
     echo
 
-    pushd content-api/data
     account=$(gcloud config get-value account 2> /dev/null)
     if [[ -z "$USE_DEFAULT_ACCOUNT" ]]; then
         read -rp "Please input an email address for an approver. This email will be added to the Firestore database as an 'approver' and will be able to perform privileged API operations from the website frontend: [${account}]: " approver
     fi
     approver="${approver:-$account}"
 
-    GOOGLE_CLOUD_PROJECT="${STAGE_PROJECT}" python3 seed_test_approver.py "${approver}"
-    GOOGLE_CLOUD_PROJECT="${STAGE_PROJECT}" python3 seed_database.py
+    gcloud builds submit content-api/data  \
+    --substitutions=_FIREBASE_PROJECT="${STAGE_PROJECT}",_APPROVER_EMAIL="${approver}" \
+    --config=./content-api/data/cloudbuild.yaml
+
     if [ "${PROD_PROJECT}" != "${STAGE_PROJECT}" ]; then
-        GOOGLE_CLOUD_PROJECT="${PROD_PROJECT}" python3 seed_test_approver.py "${approver}"
-        GOOGLE_CLOUD_PROJECT="${PROD_PROJECT}" python3 seed_database.py
+        gcloud builds submit content-api/data  \
+        --substitutions=_FIREBASE_PROJECT="${PROD_PROJECT}",_APPROVER_EMAIL="${approver}" \
+        --config=./content-api/data/cloudbuild.yaml
     fi
-    popd
 fi # skip seeding
 
 ####################

--- a/terraform/modules/emblem-app/main.tf
+++ b/terraform/modules/emblem-app/main.tf
@@ -57,3 +57,16 @@ resource "google_storage_bucket_iam_member" "sessions-iam" {
   member = "serviceAccount:${google_service_account.website_manager.email}"
   count  = var.deploy_session_bucket ? 1 : 0
 }
+
+## Ops Cloud Build service account permission to update Firestore
+resource "google_project_service_identity" "ops_cloudbuild" {
+  provider = google-beta
+  project  = data.google_project.ops.project_id
+  service  = "cloudbuild.googleapis.com"
+}
+
+resource "google_project_iam_member" "ops_cloudbuild_datastore_user" {
+  project = var.project_id
+  role    = "roles/datastore.user"
+  member  = "serviceAccount:${google_project_service_identity.ops_cloudbuild.email}"
+}


### PR DESCRIPTION
This PR will:
- add a `requirements.txt` and `cloudbuild.yaml` to the `content-api/data` directory to support executing seed scripts in a cloud build job
- add the IAM role `datastore user` to the ops cloud build service account in the application Terraform module to allow the build job to seed firestore
- change the seeding step in `setup.sh` to use `gcloud builds submit` instead of python
Fixes #657 
Fixes #602
