### PR TITLE
chore: update renovate schedule (3 weeks)

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,20 +2,17 @@
   "extends": [
     "config:base"
   ],
+  "ignorePaths": [
+    "experimental/**"
+  ],
   "rangeStrategy": "pin",
+  "schedule": "before 10am every 3 weeks on Monday", 
   "packageRules": [
     {
       "paths": [
         "client-libs/"
       ],
       "rangeStrategy": "replace"
-    },
-    {
-      "paths": [
-        "experimental/"
-      ],
-      "rangeStrategy": "auto",
-      "schedule": ["every weekend"]
     }
   ]
 }


### PR DESCRIPTION
* Drop experimental from renovate, it will be up to the experimenter to track updates and make sure current dependencies are in place for final implementation code.
* Switch the schedule to a 3 week cycle on Mondays. This is designed to: Not trigger weekend notifications, be slightly off-cycle our team's 2-week rotation on maintenance work to ensure it doesn't synchronize with specific engineers.

I checked the validity of this schedule with https://codepen.io/rationaltiger24/full/ZExQEgK