### PR TITLE
nit: billings projects link is in beta now

### DIFF
--- a/terraform/clean_project_setup.sh
+++ b/terraform/clean_project_setup.sh
@@ -53,10 +53,11 @@ gcloud projects create $PROD_PROJECT --organization $EMBLEM_ORGANIZATION -q | \
 gcloud projects create $STAGE_PROJECT --organization $EMBLEM_ORGANIZATION -q | \
 gcloud projects create $OPS_PROJECT --organization $EMBLEM_ORGANIZATION -q
 
-# Link billing accounts
-gcloud alpha billing projects link $PROD_PROJECT --billing-account $EMBLEM_BILLING_ACCOUNT
-gcloud alpha billing projects link $STAGE_PROJECT --billing-account $EMBLEM_BILLING_ACCOUNT
-gcloud alpha billing projects link $OPS_PROJECT --billing-account $EMBLEM_BILLING_ACCOUNT
+# Link billing accounts 
+# Reference https://cloud.google.com/sdk/gcloud/reference/beta/billing/projects/link
+gcloud beta billing projects link $PROD_PROJECT --billing-account $EMBLEM_BILLING_ACCOUNT
+gcloud beta billing projects link $STAGE_PROJECT --billing-account $EMBLEM_BILLING_ACCOUNT
+gcloud beta billing projects link $OPS_PROJECT --billing-account $EMBLEM_BILLING_ACCOUNT
 
 # Run setup script
 pushd ..


### PR DESCRIPTION
move over to beta since managing billing in projects is in beta now. (assuming beta might be more stable than alpha) 
https://cloud.google.com/sdk/gcloud/reference/beta/billing/projects/link