### PR TITLE
feat(issue-557): adding descriptions for build triggers

### DIFF
--- a/terraform/modules/emblem-app/deploy.tf
+++ b/terraform/modules/emblem-app/deploy.tf
@@ -59,6 +59,7 @@ resource "google_cloudbuild_trigger" "web_deploy" {
   count   = var.setup_cd_system ? 1 : 0
   project = var.ops_project_id
   name    = "web-deploy-${var.environment}"
+  description  = "Triggers on any new website build to Artifact Registry. Begins container deployment for staging/prod environment.
   pubsub_config {
     topic = var.deploy_trigger_topic_id
   }
@@ -90,6 +91,7 @@ resource "google_cloudbuild_trigger" "api_deploy" {
   count   = var.setup_cd_system ? 1 : 0
   project = var.ops_project_id
   name    = "api-deploy-${var.environment}"
+  description  = "Triggers on any new content-api build to Artifact Registry. Begins container deployment for staging/prod environment."
   pubsub_config {
     topic = var.deploy_trigger_topic_id
   }
@@ -123,6 +125,7 @@ resource "google_cloudbuild_trigger" "web_canary" {
   count   = var.setup_cd_system ? 1 : 0
   project = var.ops_project_id
   name    = "web-canary-${var.environment}"
+  description  = "Triggers on initial environment (staging, prod) deployment for website container. Performs general health check before increasing traffic."
   pubsub_config {
     topic = google_pubsub_topic.canary.id
   }
@@ -155,6 +158,7 @@ resource "google_cloudbuild_trigger" "api_canary" {
   count   = var.setup_cd_system ? 1 : 0
   project = var.ops_project_id
   name    = "api-canary-${var.environment}"
+  description  = "Triggers on initial environment (staging, prod) deployment for content-api container. Performs general health check before increasing traffic."
   pubsub_config {
     topic = google_pubsub_topic.canary.id
   }

--- a/terraform/modules/emblem-app/deploy.tf
+++ b/terraform/modules/emblem-app/deploy.tf
@@ -56,10 +56,10 @@ resource "google_project_iam_member" "cloudbuild_role_run_admin" {
 ## Start Deploy ##
 
 resource "google_cloudbuild_trigger" "web_deploy" {
-  count   = var.setup_cd_system ? 1 : 0
-  project = var.ops_project_id
-  name    = "web-deploy-${var.environment}"
-  description  = "Triggers on any new website build to Artifact Registry. Begins container deployment for staging/prod environment.
+  count       = var.setup_cd_system ? 1 : 0
+  project     = var.ops_project_id
+  name        = "web-deploy-${var.environment}"
+  description = "Triggers on any new website build to Artifact Registry. Begins container deployment for staging/prod environment."
   pubsub_config {
     topic = var.deploy_trigger_topic_id
   }
@@ -88,10 +88,10 @@ resource "google_cloudbuild_trigger" "web_deploy" {
 }
 
 resource "google_cloudbuild_trigger" "api_deploy" {
-  count   = var.setup_cd_system ? 1 : 0
-  project = var.ops_project_id
-  name    = "api-deploy-${var.environment}"
-  description  = "Triggers on any new content-api build to Artifact Registry. Begins container deployment for staging/prod environment."
+  count       = var.setup_cd_system ? 1 : 0
+  project     = var.ops_project_id
+  name        = "api-deploy-${var.environment}"
+  description = "Triggers on any new content-api build to Artifact Registry. Begins container deployment for staging/prod environment."
   pubsub_config {
     topic = var.deploy_trigger_topic_id
   }
@@ -122,10 +122,10 @@ resource "google_cloudbuild_trigger" "api_deploy" {
 ## Canary Traffic ##
 
 resource "google_cloudbuild_trigger" "web_canary" {
-  count   = var.setup_cd_system ? 1 : 0
-  project = var.ops_project_id
-  name    = "web-canary-${var.environment}"
-  description  = "Triggers on initial environment (staging, prod) deployment for website container. Performs general health check before increasing traffic."
+  count       = var.setup_cd_system ? 1 : 0
+  project     = var.ops_project_id
+  name        = "web-canary-${var.environment}"
+  description = "Triggers on initial environment (staging, prod) deployment for website container. Performs general health check before increasing traffic."
   pubsub_config {
     topic = google_pubsub_topic.canary.id
   }
@@ -155,10 +155,10 @@ resource "google_cloudbuild_trigger" "web_canary" {
 }
 
 resource "google_cloudbuild_trigger" "api_canary" {
-  count   = var.setup_cd_system ? 1 : 0
-  project = var.ops_project_id
-  name    = "api-canary-${var.environment}"
-  description  = "Triggers on initial environment (staging, prod) deployment for content-api container. Performs general health check before increasing traffic."
+  count       = var.setup_cd_system ? 1 : 0
+  project     = var.ops_project_id
+  name        = "api-canary-${var.environment}"
+  description = "Triggers on initial environment (staging, prod) deployment for content-api container. Performs general health check before increasing traffic."
   pubsub_config {
     topic = google_pubsub_topic.canary.id
   }

--- a/terraform/modules/ops/build.tf
+++ b/terraform/modules/ops/build.tf
@@ -6,7 +6,7 @@ resource "google_cloudbuild_trigger" "api_push_to_main" {
   name           = "api-push-to-main"
   filename       = "ops/api-build.cloudbuild.yaml"
   included_files = ["content-api/**"]
-  description  = "Triggers on every change to main branch in content-api directory. Initiates content-api image build."
+  description    = "Triggers on every change to main branch in content-api directory. Initiates content-api image build."
   github {
     owner = var.repo_owner
     name  = var.repo_name
@@ -28,11 +28,11 @@ resource "google_cloudbuild_trigger" "api_push_to_main" {
 }
 
 resource "google_cloudbuild_trigger" "web_push_to_main" {
-  project  = var.project_id
-  count    = var.setup_cd_system ? 1 : 0
-  name     = "web-push-to-main"
-  filename = "ops/web-build.cloudbuild.yaml"
-  description  = "Triggers on every change to main branch in website directory. Initiates website image build."
+  project     = var.project_id
+  count       = var.setup_cd_system ? 1 : 0
+  name        = "web-push-to-main"
+  filename    = "ops/web-build.cloudbuild.yaml"
+  description = "Triggers on every change to main branch in website directory. Initiates website image build."
   included_files = [
     "website/*",
     "website/*/*",

--- a/terraform/modules/ops/build.tf
+++ b/terraform/modules/ops/build.tf
@@ -6,6 +6,7 @@ resource "google_cloudbuild_trigger" "api_push_to_main" {
   name           = "api-push-to-main"
   filename       = "ops/api-build.cloudbuild.yaml"
   included_files = ["content-api/**"]
+  description  = "Triggers on every change to main branch in content-api directory. Initiates content-api image build."
   github {
     owner = var.repo_owner
     name  = var.repo_name
@@ -31,6 +32,7 @@ resource "google_cloudbuild_trigger" "web_push_to_main" {
   count    = var.setup_cd_system ? 1 : 0
   name     = "web-push-to-main"
   filename = "ops/web-build.cloudbuild.yaml"
+  description  = "Triggers on every change to main branch in website directory. Initiates website image build."
   included_files = [
     "website/*",
     "website/*/*",

--- a/terraform/modules/ops/testing.tf
+++ b/terraform/modules/ops/testing.tf
@@ -32,6 +32,7 @@ resource "google_cloudbuild_trigger" "api_unit_tests" {
     _DIR             = "content-api"
     _SERVICE_ACCOUNT = google_service_account.test_user.email
   }
+  description  = "Triggers on every pull request with content-api directory changes. Runs api unit tests."
   github {
     owner = var.repo_owner
     name  = var.repo_name
@@ -54,6 +55,7 @@ resource "google_cloudbuild_trigger" "web_system_tests" {
   count    = var.setup_cd_system ? 1 : 0
   name     = "web-system-tests"
   filename = "ops/web-e2e.cloudbuild.yaml"
+  description  = "Triggers on every pull request with website directory changes. Runs system tests."
   included_files = [
     "website/**",
     "ops/web-e2e.cloudbuild.yaml"
@@ -87,7 +89,7 @@ resource "google_cloudbuild_trigger" "e2e_nightly_tests" {
   project = var.project_id
   count   = 0
   name    = "e2e-nightly-tests"
-
+  description  = "Triggers via nightly Cloud Scheduler. Builds e2e container image."
   pubsub_config {
     topic = google_pubsub_topic.nightly.id
   }
@@ -116,6 +118,7 @@ resource "google_cloudbuild_trigger" "e2e_testing_build_runner" {
   count    = 0
   name     = "e2e-runner-push-to-main"
   filename = "ops/e2e-runner-build.cloudbuild.yaml"
+  description  = "Triggers on every change to main in the website/e2e-test directory. Builds e2e container image."
   included_files = [
     "website/e2e-test/*",
   ]

--- a/terraform/modules/ops/testing.tf
+++ b/terraform/modules/ops/testing.tf
@@ -32,7 +32,7 @@ resource "google_cloudbuild_trigger" "api_unit_tests" {
     _DIR             = "content-api"
     _SERVICE_ACCOUNT = google_service_account.test_user.email
   }
-  description  = "Triggers on every pull request with content-api directory changes. Runs api unit tests."
+  description = "Triggers on every pull request with content-api directory changes. Runs api unit tests."
   github {
     owner = var.repo_owner
     name  = var.repo_name
@@ -51,11 +51,11 @@ resource "google_cloudbuild_trigger" "api_unit_tests" {
 ###################
 
 resource "google_cloudbuild_trigger" "web_system_tests" {
-  project  = var.project_id
-  count    = var.setup_cd_system ? 1 : 0
-  name     = "web-system-tests"
-  filename = "ops/web-e2e.cloudbuild.yaml"
-  description  = "Triggers on every pull request with website directory changes. Runs system tests."
+  project     = var.project_id
+  count       = var.setup_cd_system ? 1 : 0
+  name        = "web-system-tests"
+  filename    = "ops/web-e2e.cloudbuild.yaml"
+  description = "Triggers on every pull request with website directory changes. Runs system tests."
   included_files = [
     "website/**",
     "ops/web-e2e.cloudbuild.yaml"
@@ -86,10 +86,10 @@ resource "google_cloudbuild_trigger" "web_system_tests" {
 # the filename parameter, which is not required, but still populated by
 # the API.  Investigate work-around.
 resource "google_cloudbuild_trigger" "e2e_nightly_tests" {
-  project = var.project_id
-  count   = 0
-  name    = "e2e-nightly-tests"
-  description  = "Triggers via nightly Cloud Scheduler. Builds e2e container image."
+  project     = var.project_id
+  count       = 0
+  name        = "e2e-nightly-tests"
+  description = "Triggers via nightly Cloud Scheduler. Builds e2e container image."
   pubsub_config {
     topic = google_pubsub_topic.nightly.id
   }
@@ -114,11 +114,11 @@ resource "google_cloudbuild_trigger" "e2e_nightly_tests" {
 }
 
 resource "google_cloudbuild_trigger" "e2e_testing_build_runner" {
-  project  = var.project_id
-  count    = 0
-  name     = "e2e-runner-push-to-main"
-  filename = "ops/e2e-runner-build.cloudbuild.yaml"
-  description  = "Triggers on every change to main in the website/e2e-test directory. Builds e2e container image."
+  project     = var.project_id
+  count       = 0
+  name        = "e2e-runner-push-to-main"
+  filename    = "ops/e2e-runner-build.cloudbuild.yaml"
+  description = "Triggers on every change to main in the website/e2e-test directory. Builds e2e container image."
   included_files = [
     "website/e2e-test/*",
   ]


### PR DESCRIPTION
**Issue:** #557  Adding more color to what each build trigger does. 

**To reproduce:**
* Execute full script `sh setup.sh` or solely delivery (if you have a working version of Emblem already set up) `scripts/configure_delivery.sh` to update terraform `google_cloudbuild_trigger` resources
* After full deployment, you should see the descriptions for each trigger updated like so:

<img width="550" alt="Screen Shot 2022-10-11 at 2 42 08 PM" src="https://user-images.githubusercontent.com/1331216/195204572-06187dd2-5833-453c-b3da-b6a00b6fc9aa.png">
