### PR TITLE
fix: add project flag to `gcloud builds describe` in `setup.sh`

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -181,19 +181,19 @@ check_for_build_then_run () {
     local build_id="${1}"
     local run_command="${2}"
     # Wait for build to complete.
-    if [ $(gcloud builds describe $build_id --format='value(status)') == "WORKING" ]; then
-        log_url=$(gcloud builds describe $build_id --format='value(logUrl)')
+    if [ $(gcloud builds describe $build_id --project=$OPS_PROJECT  --format='value(status)') == "WORKING" ]; then
+        log_url=$(gcloud builds describe $build_id --project=$OPS_PROJECT --format='value(logUrl)')
         echo "Build $build_id still working."
         echo "Logs are available at [ $log_url ]."
-        while [ $(gcloud builds describe $build_id --format='value(status)') == "WORKING" ]
+        while [ $(gcloud builds describe $build_id --project=$OPS_PROJECT  --format='value(status)') == "WORKING" ]
         do
           echo "Build $build_id still working..."
           sleep 10
         done
     fi
     # Return error and build log for failures. 
-    if [ $(gcloud builds describe $build_id --format='value(status)') == "FAILURE" ]; then
-        build_describe=$(gcloud builds describe $build_id --format='csv(failureInfo.detail,logUrl)[no-heading]')
+    if [ $(gcloud builds describe $build_id --project=$OPS_PROJECT --format='value(status)') == "FAILURE" ]; then
+        build_describe=$(gcloud builds describe $build_id --project=$OPS_PROJECT --format='csv(failureInfo.detail,logUrl)[no-heading]')
         fail_info=$(echo $build_describe | awk -F',' '{gsub(/""/,"\"");print $1}')
         log_url=$(echo $build_describe | awk -F',' '{print $2}')
         echo "Build ${build_id} failed. See build log: $log_url"
@@ -201,11 +201,11 @@ check_for_build_then_run () {
         echo "Please re-run setup."
         exit 2
     # Deploy if build is successful.
-    elif [ $(gcloud builds describe $build_id --format='value(status)') == "SUCCESS" ]; then
+    elif [ $(gcloud builds describe $build_id --project=$OPS_PROJECT --format='value(status)') == "SUCCESS" ]; then
         $run_command
     # Return build log for all other statuses.
     else
-        log_url=$(gcloud builds describe $build_id --format='value(logUrl)')
+        log_url=$(gcloud builds describe $build_id --project=$OPS_PROJECT --format='value(logUrl)')
         echo "Build ${build_id} did not complete." 
         echo "See build log: $log_url"
         echo "Please re-run setup."


### PR DESCRIPTION
This PR will:
- add the `--project` flag to all instances of `gcloud builds describe` used in `setup.sh` to specify ops project. 

Fixes #699 