### PR TITLE
refactor: update readme to enable build api for first step

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,6 @@ This project features:
     * Artifact Registry
     * Pub/Sub
 
-
 Go deeper into project details in the [documentation](./docs) or read through the [technical decisions](docs/decisions/README.md) that got us where we are today.
 
 ## Service architecture
@@ -60,7 +59,11 @@ We recommend running through setup steps using Google Cloud Shell, which has the
 
 1. **Connect a fork of this Github repo to your Emblem ops project**
    
-   Connect your repository to your Google Cloud Project via the [Cloud Build triggers page in the Google Cloud Console](https://console.cloud.google.com/cloud-build/triggers/connect). Make sure you are working from your **ops** project. This will require you to authenticate with your Github account.
+   Connect your repository to your Google Cloud Project via the [Cloud Build triggers page in the Google Cloud Console](https://console.cloud.google.com/cloud-build/triggers/connect). Make sure you are working from your **ops** project. This will require you to enable the Cloud Build API and authenticate with your Github account.
+
+   ```
+   gcloud services enable cloudbuild.googleapis.com
+   ```
 
    Principals with access to your Google Cloud project will be able to create and run triggers on the repository you use.
 
@@ -69,6 +72,7 @@ We recommend running through setup steps using Google Cloud Shell, which has the
    The streamlined setup uses `setup.sh` to deploy Emblem resources via Terraform and the `gcloud` CLI.
 
    Create three environment variables (PROD_PROJECT, STAGE_PROJECT, OPS_PROJECT) with their respective project id's.
+   
    ```
    export PROD_PROJECT=<YOUR_PROD_PROJECT_ID>
    export STAGE_PROJECT=<YOUR_STAGE_PROJECT_ID>


### PR DESCRIPTION
**Issue:** Add clarifying step for when we direct users to connect Cloud Build Triggers w/ a forked emblem repo