### PR TITLE
fix: terraform build trigger filename parameter

### DIFF
--- a/terraform/modules/emblem-app/deploy.tf
+++ b/terraform/modules/emblem-app/deploy.tf
@@ -67,6 +67,7 @@ resource "google_cloudbuild_trigger" "web_deploy" {
     approval_required = var.require_deploy_approval
   }
   filter = "_IMAGE_NAME.matches('website')"
+  filename = "ops/deploy.cloudbuild.yaml"
   substitutions = {
     _BODY           = "$(body)"
     _ENV            = var.environment
@@ -79,10 +80,6 @@ resource "google_cloudbuild_trigger" "web_deploy" {
   source_to_build {
     uri       = format("https://github.com/%s/%s", var.repo_owner, var.repo_name)
     ref       = "refs/heads/main"
-    repo_type = "GITHUB"
-  }
-  git_file_source {
-    path      = "ops/deploy.cloudbuild.yaml"
     repo_type = "GITHUB"
   }
 }
@@ -99,6 +96,7 @@ resource "google_cloudbuild_trigger" "api_deploy" {
     approval_required = var.require_deploy_approval
   }
   filter = "_IMAGE_NAME.matches('content-api')"
+  filename = "ops/deploy.cloudbuild.yaml"
   substitutions = {
     _BODY           = "$(body)"
     _ENV            = var.environment
@@ -111,10 +109,6 @@ resource "google_cloudbuild_trigger" "api_deploy" {
   source_to_build {
     uri       = format("https://github.com/%s/%s", var.repo_owner, var.repo_name)
     ref       = "refs/heads/main"
-    repo_type = "GITHUB"
-  }
-  git_file_source {
-    path      = "ops/deploy.cloudbuild.yaml"
     repo_type = "GITHUB"
   }
 }
@@ -133,6 +127,7 @@ resource "google_cloudbuild_trigger" "web_canary" {
     approval_required = false
   }
   filter = format("_SERVICE.matches('%s')", "website")
+  filename = "ops/canary.cloudbuild.yaml"
   substitutions = {
     _BODY           = "$(body)"
     _ENV            = var.environment
@@ -146,10 +141,6 @@ resource "google_cloudbuild_trigger" "web_canary" {
   source_to_build {
     uri       = format("https://github.com/%s/%s", var.repo_owner, var.repo_name)
     ref       = "refs/heads/main"
-    repo_type = "GITHUB"
-  }
-  git_file_source {
-    path      = "ops/canary.cloudbuild.yaml"
     repo_type = "GITHUB"
   }
 }
@@ -166,6 +157,7 @@ resource "google_cloudbuild_trigger" "api_canary" {
     approval_required = false
   }
   filter = format("_SERVICE.matches('%s')", "content-api")
+  filename = "ops/canary.cloudbuild.yaml"
   substitutions = {
     _BODY           = "$(body)"
     _ENV            = var.environment
@@ -179,10 +171,6 @@ resource "google_cloudbuild_trigger" "api_canary" {
   source_to_build {
     uri       = format("https://github.com/%s/%s", var.repo_owner, var.repo_name)
     ref       = "refs/heads/main"
-    repo_type = "GITHUB"
-  }
-  git_file_source {
-    path      = "ops/canary.cloudbuild.yaml"
     repo_type = "GITHUB"
   }
 }

--- a/terraform/modules/emblem-app/deploy.tf
+++ b/terraform/modules/emblem-app/deploy.tf
@@ -66,7 +66,7 @@ resource "google_cloudbuild_trigger" "web_deploy" {
   approval_config {
     approval_required = var.require_deploy_approval
   }
-  filter = "_IMAGE_NAME.matches('website')"
+  filter   = "_IMAGE_NAME.matches('website')"
   filename = "ops/deploy.cloudbuild.yaml"
   substitutions = {
     _BODY           = "$(body)"
@@ -95,7 +95,7 @@ resource "google_cloudbuild_trigger" "api_deploy" {
   approval_config {
     approval_required = var.require_deploy_approval
   }
-  filter = "_IMAGE_NAME.matches('content-api')"
+  filter   = "_IMAGE_NAME.matches('content-api')"
   filename = "ops/deploy.cloudbuild.yaml"
   substitutions = {
     _BODY           = "$(body)"
@@ -126,7 +126,7 @@ resource "google_cloudbuild_trigger" "web_canary" {
   approval_config {
     approval_required = false
   }
-  filter = format("_SERVICE.matches('%s')", "website")
+  filter   = format("_SERVICE.matches('%s')", "website")
   filename = "ops/canary.cloudbuild.yaml"
   substitutions = {
     _BODY           = "$(body)"
@@ -156,7 +156,7 @@ resource "google_cloudbuild_trigger" "api_canary" {
   approval_config {
     approval_required = false
   }
-  filter = format("_SERVICE.matches('%s')", "content-api")
+  filter   = format("_SERVICE.matches('%s')", "content-api")
   filename = "ops/canary.cloudbuild.yaml"
   substitutions = {
     _BODY           = "$(body)"


### PR DESCRIPTION
This PR:
- updates 4 `google_cloudbuild_trigger` resources in the emblem-app module to use the `filename` parameter instead of the `git_file_source` block

fixes #718 

This causes no change to resources but will prevent Terraform anticipating changes upon re-run.  