### PR TITLE
fix(setup): fix {TF, env} variable logic

### DIFF
--- a/scripts/configure_delivery.sh
+++ b/scripts/configure_delivery.sh
@@ -68,30 +68,23 @@ done
 
 # Ops Project
 OPS_ENVIRONMENT_DIR=terraform/environments/ops
+TFVARS_FILE="${OPS_ENVIRONMENT_DIR}/terraform.tfvars"
+TFVARS=$(grep -zvwE "repo_(owner|name)" $TFVARS_FILE)
+(echo "$TFVARS") > $TFVARS_FILE
 cat >> "${OPS_ENVIRONMENT_DIR}/terraform.tfvars" <<EOF
-setup_cd_system="true"
 repo_owner="${REPO_OWNER}"
 repo_name="${REPO_NAME}"
 EOF
 terraform -chdir=${OPS_ENVIRONMENT_DIR} apply --auto-approve
 
 # Staging Project
+export TF_VAR_ops_project_id="$OPS_PROJECT"
 STAGE_ENVIRONMENT_DIR=terraform/environments/staging
-cat >> "${STAGE_ENVIRONMENT_DIR}/terraform.tfvars" <<EOF
-setup_cd_system="true"
-repo_owner="${REPO_OWNER}"
-repo_name="${REPO_NAME}"
-EOF
 terraform -chdir=${STAGE_ENVIRONMENT_DIR} apply --auto-approve
 
 # Prod Project
 # Only deploy to separate project for multi-project setups
 if [ "${PROD_PROJECT}" != "${STAGE_PROJECT}" ]; then 
     PROD_ENVIRONMENT_DIR=terraform/environments/prod
-cat >> "${PROD_ENVIRONMENT_DIR}/terraform.tfvars" <<EOF
-setup_cd_system="true"
-repo_owner="${REPO_OWNER}"
-repo_name="${REPO_NAME}"
-EOF
     terraform -chdir=${PROD_ENVIRONMENT_DIR} apply --auto-approve
 fi


### PR DESCRIPTION
Fixes in this PR:
- Fix setup.sh not overwriting old `.tfvars` files
- Fix vars being set across multiple `.tfvars` files (this causes conflicts)
- Prevent deploys to Cloud Run if builds are skipped
- Move `ops_project_id` into an env var _(it's used in multiple places; **opinion:** exporting it is easier than managing multiple `.tfvars` files)_

Question:
> If the CD system is already in place, the first `tf apply` in `setup.sh` will delete it because `setup_cd_system` is hard-coded to **false**.
>
> While it *does* get reprovisioned later, the "resources will be deleted" TF output might look very scary to end-users.
>
> Can we fix that in this PR?