### PR TITLE
feat: run setup terraform via build jobs

### DIFF
--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -1,0 +1,189 @@
+#!/bin/bash
+set -eu
+
+_error_report() {
+  echo >&2 "Exited [$?] at line $(caller):"
+  cat -n $0 | tail -n+$(($1 - 3)) | head -n7 | sed "4s/^\s*/>>> /"
+}
+trap '_error_report $LINENO' ERR
+
+# Formatting variables
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+NC='\033[0m'
+
+# Check env variables are not empty strings
+if [[ -z "${PROD_PROJECT:-}" ]]; then
+    echo -e "---\n${RED}Emblem bootstrap error:${NC} Please set the $(tput bold)PROD_PROJECT$(tput sgr0) environment variable \n---"
+    exit 1
+elif [[ -z "${STAGE_PROJECT:-}" ]]; then
+    echo -e "---\n${RED}Emblem bootstrap error:${NC} Please set the $(tput bold)STAGE_PROJECT$(tput sgr0) environment variable \n---"
+    exit 1
+elif [[ -z "${OPS_PROJECT:-}" ]]; then
+    echo -e "---\n${RED}Emblem bootstrap error:${NC} Please set the $(tput bold)OPS_PROJECT$(tput sgr0) environment variable \n---"
+    exit 1
+fi
+
+echo -e "Bootstrapping Emblem...\n"
+
+# Set other variables
+OPS_PROJECT_NUMBER=$(gcloud projects list --format='value(PROJECT_NUMBER)' --filter=PROJECT_ID=$OPS_PROJECT)
+if [[ -z "${OPS_PROJECT_NUMBER}" ]]; then
+    echo -e "---\n${RED}Emblem bootstrap error:${NC} Could not retrieve project number for $(tput bold)${OPS_PROJECT}$(tput sgr0).\n---"
+    exit 1
+fi
+
+EMBLEM_TF_SERVICE_ACCOUNT=emblem-terraformer@${OPS_PROJECT}.iam.gserviceaccount.com
+BUILD_SERVICE_ACCOUNT=${OPS_PROJECT_NUMBER}@cloudbuild.gserviceaccount.com
+REPO_CONNECT_URL="https://console.cloud.google.com/cloud-build/triggers/connect?project=${OPS_PROJECT}"
+STATE_GCS_BUCKET_NAME="$OPS_PROJECT-tf-states"
+OPS_IAM="bindings:
+- members:
+  - serviceAccount:${EMBLEM_TF_SERVICE_ACCOUNT}
+  role: roles/cloudbuild.builds.editor
+- members:
+  - serviceAccount:${EMBLEM_TF_SERVICE_ACCOUNT}
+  role: roles/secretmanager.admin
+- members:
+  - serviceAccount:${EMBLEM_TF_SERVICE_ACCOUNT}
+  role: roles/pubsub.editor
+- members:
+  - serviceAccount:${EMBLEM_TF_SERVICE_ACCOUNT}
+  role: roles/iam.serviceAccountAdmin
+- members:
+  - serviceAccount:${EMBLEM_TF_SERVICE_ACCOUNT}
+  role: roles/artifactregistry.admin
+- members:
+  - serviceAccount:${EMBLEM_TF_SERVICE_ACCOUNT}
+  role: roles/resourcemanager.projectIamAdmin
+- members:
+  - serviceAccount:${EMBLEM_TF_SERVICE_ACCOUNT}
+  role: roles/serviceusage.serviceUsageAdmin"
+APP_IAM="bindings:
+- members:
+  - serviceAccount:${EMBLEM_TF_SERVICE_ACCOUNT}
+  role: roles/serviceusage.serviceUsageAdmin
+- members:
+  - serviceAccount:${EMBLEM_TF_SERVICE_ACCOUNT}
+  role: roles/storage.admin
+- members:
+  - serviceAccount:${EMBLEM_TF_SERVICE_ACCOUNT}
+  role: roles/resourcemanager.projectIamAdmin
+- members:
+  - serviceAccount:${EMBLEM_TF_SERVICE_ACCOUNT}
+  role: roles/iam.serviceAccountAdmin
+- members:
+  - serviceAccount:${EMBLEM_TF_SERVICE_ACCOUNT}
+  role: roles/firebase.managementServiceAgent"
+
+# Services needed for Terraform to manage resources via service account 
+
+echo -e "\n\xe2\x88\xb4 Enabling initial required services... "
+gcloud services enable --project $OPS_PROJECT --async \
+    iamcredentials.googleapis.com \
+    cloudresourcemanager.googleapis.com \
+    compute.googleapis.com \
+    serviceusage.googleapis.com \
+    appengine.googleapis.com \
+    cloudbuild.googleapis.com > /dev/null
+
+# Create terraform service account
+if gcloud iam service-accounts describe \
+    $EMBLEM_TF_SERVICE_ACCOUNT \
+    --project $OPS_PROJECT &> /dev/null ; then
+        echo -e "\n\xe2\x88\xb4 Using existing Emblem Terraform service account:  $EMBLEM_TF_SERVICE_ACCOUNT "
+else
+    echo -e "\n\xe2\x88\xb4 Creating Emblem Terraform service account: $EMBLEM_TF_SERVICE_ACCOUNT "
+    gcloud iam service-accounts create emblem-terraformer \
+        --project="$OPS_PROJECT" \
+        --description="Service account for deploying resources via Terraform" \
+        --display-name="Emblem Terraformer"
+fi
+
+# Give cloud build service account token creator on terraform service account policy
+echo -e "\n\xe2\x88\xb4 Updating Terraform service account IAM policy... "
+gcloud iam service-accounts add-iam-policy-binding --project=$OPS_PROJECT \
+    $EMBLEM_TF_SERVICE_ACCOUNT \
+    --member="serviceAccount:${BUILD_SERVICE_ACCOUNT}" \
+    --role="roles/iam.serviceAccountTokenCreator" &> /dev/null
+
+# Ops permissions
+echo -e "\n\xe2\x88\xb4 Updating ops project IAM policy... "
+
+OPS_CURRENT_IAM=$(gcloud projects get-iam-policy $OPS_PROJECT --format=yaml | tail -n +2)
+
+echo -e "${OPS_IAM}\n${OPS_CURRENT_IAM}" | \
+    gcloud projects set-iam-policy $OPS_PROJECT /dev/stdin > /dev/null
+
+# App permissions for stage and prod
+
+echo -e "\n\xe2\x88\xb4 Updating stage project IAM policy... "
+
+STAGE_CURRENT_IAM=$(gcloud projects get-iam-policy $STAGE_PROJECT --format=yaml | tail -n +2)
+
+echo -e "${APP_IAM}\n${STAGE_CURRENT_IAM}" | \
+    gcloud projects set-iam-policy $STAGE_PROJECT /dev/stdin > /dev/null
+
+echo -e "\n\xe2\x88\xb4 Updating prod project IAM policy... "
+PROD_CURRENT_IAM=$(gcloud projects get-iam-policy $PROD_PROJECT --format=yaml | tail -n +2)
+echo -e "${APP_IAM}\n${PROD_CURRENT_IAM}" | \
+    gcloud projects set-iam-policy $PROD_PROJECT /dev/stdin > /dev/null
+
+# Setup Terraform state bucket
+
+if gcloud storage buckets list gs://$STATE_GCS_BUCKET_NAME &> /dev/null ; then
+    echo -e "\n\xe2\x88\xb4 Using existing Terraform remote state bucket: gs://${STATE_GCS_BUCKET_NAME} "
+    gcloud storage buckets update gs://$STATE_GCS_BUCKET_NAME --versioning > /dev/null
+else
+    echo -e "\n\xe2\x88\xb4 Creating Terraform remote state bucket: gs://${STATE_GCS_BUCKET_NAME} "
+    gcloud storage buckets create gs://${STATE_GCS_BUCKET_NAME} --project=$OPS_PROJECT > /dev/null
+    echo -e "\n\xe2\x88\xb4 Enabling versioning... "
+    gcloud storage buckets update gs://$STATE_GCS_BUCKET_NAME --versioning > /dev/null
+fi
+
+echo -e "\n\xe2\x88\xb4 Setting storage bucket IAM policy for Terraform service account..."
+# Note: `gcloud storage buckets` does not support `add-iam-policy-binding` in 
+# Google Cloud SDK 410.0.0 (current default in Cloud Shell).
+gsutil iam ch serviceAccount:${EMBLEM_TF_SERVICE_ACCOUNT}:admin \
+  gs://${STATE_GCS_BUCKET_NAME}
+
+# Add GitHub repo to ops project
+echo -e "\n${GREEN}\xE2\x9E\xA8 Connect a fork of the Emblem GitHub repo to your ops project via the Cloud Console:${NC} $(tput bold)${REPO_CONNECT_URL}$(tput sgr0) \n"
+read -n 1 -r -s -p $'Once your forked Emblem repo is connected, please type any key to continue.\n'
+
+continue=1
+while [[ ${continue} -gt 0 ]]; do
+    read -rp "Please input the GitHub repository owner: " REPO_OWNER
+    read -rp "Please input the GitHub repository name: " REPO_NAME
+    echo -e "\n"
+    read -rp "Is this the correct repository URL? $(tput bold)https://github.com/${REPO_OWNER}/${REPO_NAME}$(tput sgr0)? (Y/n) " yesno
+
+    case "$yesno" in
+    [yY][eE][sS]|[yY]|"") 
+        continue=0
+        ;;
+    *)
+        continue=1
+        ;;
+    esac
+done
+
+echo -e "\n\xe2\x88\xb4 Adding repo information to project metadata... "
+
+# Values for repo owner and name are stored in project metadata. Wait for 
+# the service to finish enabling before continuing.
+
+while [[ ! $(gcloud services list --project=$OPS_PROJECT \
+    --format="value[](config.name)" \
+    --filter=config.name:compute.googleapis.com) ]]
+    do
+        echo -e "\xe2\x88\xb4 Waiting for services... "
+        sleep 5
+    done
+gcloud compute project-info add-metadata --project=$OPS_PROJECT \
+    --metadata=REPO_NAME=$REPO_NAME > /dev/null
+
+gcloud compute project-info add-metadata --project=$OPS_PROJECT \
+    --metadata=REPO_OWNER=$REPO_OWNER > /dev/null
+
+echo -e "\n${GREEN}Emblem bootstrapping complete! Please run setup.sh${NC} \n"

--- a/scripts/configure_delivery.sh
+++ b/scripts/configure_delivery.sh
@@ -50,11 +50,15 @@ REPO_OWNER="$(gcloud compute project-info describe \
 # Ops Project
 OPS_ENVIRONMENT_DIR=terraform/environments/ops
 cat > "${OPS_ENVIRONMENT_DIR}/terraform.tfvars" <<EOF
+project_id = "${OPS_PROJECT}"
 setup_cd_system="true"
 repo_owner="${REPO_OWNER}"
 repo_name="${REPO_NAME}"
 EOF
-terraform -chdir=${OPS_ENVIRONMENT_DIR} apply --auto-approve
+
+gcloud builds submit ./terraform --project="$OPS_PROJECT" \
+    --config=./ops/terraform.cloudbuild.yaml \
+    --substitutions=_ENV="ops",_STATE_GCS_BUCKET_NAME=$STATE_GCS_BUCKET_NAME,_TF_SERVICE_ACCT=$TERRAFORM_SERVICE_ACCOUNT
 
 # Staging Project
 STAGE_ENVIRONMENT_DIR=terraform/environments/staging

--- a/scripts/configure_delivery.sh
+++ b/scripts/configure_delivery.sh
@@ -40,35 +40,9 @@ elif [[ -z "${OPS_PROJECT}" ]]; then
     exit 1
 fi
 
-REPO_CONNECT_URL="https://console.cloud.google.com/cloud-build/triggers/connect?project=${OPS_PROJECT}"
-echo "Connect your repos: ${REPO_CONNECT_URL}"
-read -n 1 -r -s -p $'Once your forked emblem repo is connected, please continue by typing any key.\n'
-
-if [[ -z "${REPO_NAME}" ]]
-then
-    continue=1
-else
-    continue=0
-fi
-
-while [[ ${continue} -gt 0 ]]; do
-    read -rp "Please input the GitHub repository owner: " REPO_OWNER
-    read -rp "Please input the GitHub repository name: " REPO_NAME
-    read -rp "Integrate Cloud Build with the repository $(tput bold)https://github.com/${REPO_OWNER}/${REPO_NAME}$(tput sgr0)? (Y/n) " yesno
-
-    case "$yesno" in
-    [yY][eE][sS]|[yY]|"") 
-        continue=0
-        ;;
-    *)
-        continue=1
-        ;;
-    esac
-done
-
 # Ops Project
 OPS_ENVIRONMENT_DIR=terraform/environments/ops
-cat >> "${OPS_ENVIRONMENT_DIR}/terraform.tfvars" <<EOF
+cat > "${OPS_ENVIRONMENT_DIR}/terraform.tfvars" <<EOF
 setup_cd_system="true"
 repo_owner="${REPO_OWNER}"
 repo_name="${REPO_NAME}"
@@ -77,7 +51,7 @@ terraform -chdir=${OPS_ENVIRONMENT_DIR} apply --auto-approve
 
 # Staging Project
 STAGE_ENVIRONMENT_DIR=terraform/environments/staging
-cat >> "${STAGE_ENVIRONMENT_DIR}/terraform.tfvars" <<EOF
+cat > "${STAGE_ENVIRONMENT_DIR}/terraform.tfvars" <<EOF
 setup_cd_system="true"
 repo_owner="${REPO_OWNER}"
 repo_name="${REPO_NAME}"

--- a/scripts/configure_delivery.sh
+++ b/scripts/configure_delivery.sh
@@ -40,6 +40,13 @@ elif [[ -z "${OPS_PROJECT}" ]]; then
     exit 1
 fi
 
+REPO_NAME="$(gcloud compute project-info describe \
+    --project=${OPS_PROJECT} \
+    --format='value[](commonInstanceMetadata.items.REPO_NAME)')"
+REPO_OWNER="$(gcloud compute project-info describe \
+    --project=${OPS_PROJECT} \
+    --format='value[](commonInstanceMetadata.items.REPO_OWNER)')"
+
 # Ops Project
 OPS_ENVIRONMENT_DIR=terraform/environments/ops
 cat > "${OPS_ENVIRONMENT_DIR}/terraform.tfvars" <<EOF

--- a/setup.sh
+++ b/setup.sh
@@ -72,11 +72,12 @@ export STATE_GCS_BUCKET_NAME="$OPS_PROJECT-tf-states"
 # Ops Project
 OPS_ENVIRONMENT_DIR=terraform/environments/ops
 cat > "${OPS_ENVIRONMENT_DIR}/terraform.tfvars" <<EOF
-project_id = "${OPS_PROJECT}"
+    project_id = "${OPS_PROJECT}"
 EOF
-terraform -chdir=${OPS_ENVIRONMENT_DIR} init -backend-config="bucket=${STATE_GCS_BUCKET_NAME}" -backend-config="prefix=ops"
-terraform -chdir=${OPS_ENVIRONMENT_DIR} apply --auto-approve
 
+gcloud builds submit ./terraform --project="$OPS_PROJECT" \
+    --config=./ops/terraform.cloudbuild.yaml \
+    --substitutions=_ENV="ops",_STATE_GCS_BUCKET_NAME=$STATE_GCS_BUCKET_NAME,_TF_SERVICE_ACCT=$TERRAFORM_SERVICE_ACCOUNT
 
 ####################
 # Build Containers #

--- a/setup.sh
+++ b/setup.sh
@@ -67,7 +67,7 @@ echo
 echo "$(tput bold)Setting up your Cloud resources with Terraform...$(tput sgr0)"
 echo
 export TERRAFORM_SERVICE_ACCOUNT="emblem-terraformer@${OPS_PROJECT}.iam.gserviceaccount.com"
-export STATE_GCS_BUCKET_NAME="$OPS_PROJECT-tf-states"
+export STATE_GCS_BUCKET_NAME="${OPS_PROJECT}-tf-states"
 
 # Ops Project
 OPS_ENVIRONMENT_DIR=terraform/environments/ops
@@ -117,9 +117,9 @@ project_id = "${STAGE_PROJECT}"
 ops_project_id = "${OPS_PROJECT}"
 EOF
 
-STAGE_BUILD_ID="$(gcloud builds submit ./terraform --project="$OPS_PROJECT" \
+STAGE_BUILD_ID="$(gcloud builds submit ./terraform --project=${OPS_PROJECT} \
     --async --config=./ops/terraform.cloudbuild.yaml \
-    --substitutions=_ENV="staging",_STATE_GCS_BUCKET_NAME=$STATE_GCS_BUCKET_NAME,_TF_SERVICE_ACCT=$TERRAFORM_SERVICE_ACCOUNT \
+    --substitutions=_ENV='staging',_STATE_GCS_BUCKET_NAME=${STATE_GCS_BUCKET_NAME},_TF_SERVICE_ACCT=${TERRAFORM_SERVICE_ACCOUNT} \
     --format='value(ID)')"
 
 PROD_ENVIRONMENT_DIR=terraform/environments/prod
@@ -163,13 +163,13 @@ check_for_build_then_run () {
         echo "Please re-run setup."
         exit 2
     # Deploy if build is successful.
-    elif [ $(gcloud builds describe $build_id --project=$OPS_PROJECT --format='value(status)') == "SUCCESS" ]; then
+    elif [ "$(gcloud builds describe ${build_id} --project=${OPS_PROJECT} --format='value(status)')" == "SUCCESS" ]; then
         $run_command
     # Return build log for all other statuses.
     else
-        log_url=$(gcloud builds describe $build_id --project=$OPS_PROJECT --format='value(logUrl)')
+        log_url="$(gcloud builds describe ${build_id} --project=${OPS_PROJECT} --format='value(logUrl)')"
         echo "Build ${build_id} did not complete." 
-        echo "See build log: $log_url"
+        echo "See build log: ${log_url}"
         echo "Please re-run setup."
         exit 2
     fi;
@@ -178,7 +178,7 @@ check_for_build_then_run () {
 ########################
 # Seed Default Content #
 ########################
-if [[ -z "$SKIP_SEEDING" ]]; then
+if [[ -z "${SKIP_SEEDING}" ]]; then
     echo
     echo "$(tput bold)Seeding default content...$(tput sgr0)"
     echo
@@ -262,7 +262,7 @@ fi # skip deploy
 # Setup CI/CD #
 ###############
 
-if [[ -z "$SKIP_TRIGGERS" ]]; then
+if [[ -z "${SKIP_TRIGGERS}" ]]; then
     echo
 
     ./scripts/configure_delivery.sh
@@ -270,9 +270,9 @@ if [[ -z "$SKIP_TRIGGERS" ]]; then
 fi # skip triggers
 
 echo
-STAGING_WEBSITE_URL=$(gcloud run services describe website --project "${STAGE_PROJECT}" --region ${REGION} --format 'value(status.url)')
+STAGING_WEBSITE_URL="$(gcloud run services describe website --project ${STAGE_PROJECT} --region ${REGION} --format 'value(status.url)')"
 if [ "${PROD_PROJECT}" != "${STAGE_PROJECT}" ]; then
-  PROD_WEBSITE_URL=$(gcloud run services describe website --project "${PROD_PROJECT}" --region ${REGION} --format 'value(status.url)')
+  PROD_WEBSITE_URL="$(gcloud run services describe website --project ${PROD_PROJECT} --region ${REGION} --format 'value(status.url)')"
   echo "💠 The staging environment is ready! Navigate your browser to ${STAGING_WEBSITE_URL}"
   echo "💠 The production environment is ready! Navigate your browser to ${PROD_WEBSITE_URL}"
 else
@@ -283,7 +283,7 @@ fi
 # User Authentication #
 #######################
 
-if [[ -z "$SKIP_AUTH" ]]; then
+if [[ -z "${SKIP_AUTH}" ]]; then
     echo
     read -rp "Would you like to configure $(tput bold)$(tput setaf 3)end-user authentication?$(tput sgr0) (y/n) " auth_yesno
 

--- a/setup.sh
+++ b/setup.sh
@@ -66,8 +66,8 @@ echo "Setting up a new instance of Emblem. There may be a few prompts to guide t
 echo
 echo "$(tput bold)Setting up your Cloud resources with Terraform...$(tput sgr0)"
 echo
-
-STATE_GCS_BUCKET_NAME="$OPS_PROJECT-tf-states"
+export TERRAFORM_SERVICE_ACCOUNT="emblem-terraformer@${OPS_PROJECT}.iam.gserviceaccount.com"
+export STATE_GCS_BUCKET_NAME="$OPS_PROJECT-tf-states"
 
 # Create remote state bucket if it doesn't exist
 if ! gsutil ls gs://${STATE_GCS_BUCKET_NAME} > /dev/null ; then

--- a/setup.sh
+++ b/setup.sh
@@ -111,28 +111,27 @@ fi # skip build
 # Application Setup #
 #####################
 
-# Staging Project
 STAGE_ENVIRONMENT_DIR=terraform/environments/staging
 cat > "${STAGE_ENVIRONMENT_DIR}/terraform.tfvars" <<EOF
 project_id = "${STAGE_PROJECT}"
 ops_project_id = "${OPS_PROJECT}"
 EOF
-terraform -chdir=${STAGE_ENVIRONMENT_DIR} init -backend-config="bucket=${STATE_GCS_BUCKET_NAME}" -backend-config="prefix=stage"
-terraform -chdir=${STAGE_ENVIRONMENT_DIR} apply --auto-approve
 
-# Prod Project
-# Only deploy to separate project for multi-project setups
-if [ "${PROD_PROJECT}" != "${STAGE_PROJECT}" ]; then 
-    PROD_ENVIRONMENT_DIR=terraform/environments/prod
+STAGE_BUILD_ID="$(gcloud builds submit ./terraform --project="$OPS_PROJECT" \
+    --async --config=./ops/terraform.cloudbuild.yaml \
+    --substitutions=_ENV="staging",_STATE_GCS_BUCKET_NAME=$STATE_GCS_BUCKET_NAME,_TF_SERVICE_ACCT=$TERRAFORM_SERVICE_ACCOUNT \
+    --format='value(ID)')"
+
+PROD_ENVIRONMENT_DIR=terraform/environments/prod
 cat > "${PROD_ENVIRONMENT_DIR}/terraform.tfvars" <<EOF
 project_id = "${PROD_PROJECT}"
 ops_project_id = "${OPS_PROJECT}"
 EOF
-    terraform -chdir=${PROD_ENVIRONMENT_DIR} init -backend-config="bucket=${STATE_GCS_BUCKET_NAME}" -backend-config="prefix=prod"
-    terraform -chdir=${PROD_ENVIRONMENT_DIR} apply --auto-approve
-fi
 
-
+PROD_BUILD_ID="$(gcloud builds submit ./terraform --project="$OPS_PROJECT" \
+    --async --config=./ops/terraform.cloudbuild.yaml \
+    --substitutions=_ENV="prod",_STATE_GCS_BUCKET_NAME=$STATE_GCS_BUCKET_NAME,_TF_SERVICE_ACCT=$TERRAFORM_SERVICE_ACCOUNT \
+    --format='value(ID)') "
 
 ########################
 # Seed Default Content #

--- a/setup.sh
+++ b/setup.sh
@@ -69,13 +69,6 @@ echo
 export TERRAFORM_SERVICE_ACCOUNT="emblem-terraformer@${OPS_PROJECT}.iam.gserviceaccount.com"
 export STATE_GCS_BUCKET_NAME="$OPS_PROJECT-tf-states"
 
-# Create remote state bucket if it doesn't exist
-if ! gsutil ls gs://${STATE_GCS_BUCKET_NAME} > /dev/null ; then
-    echo "Creating remote state bucket: " $STATE_GCS_BUCKET_NAME
-    gsutil mb -p $OPS_PROJECT -l $REGION gs://${STATE_GCS_BUCKET_NAME}
-    gsutil versioning set on gs://${STATE_GCS_BUCKET_NAME}
-fi
-
 # Ops Project
 OPS_ENVIRONMENT_DIR=terraform/environments/ops
 cat > "${OPS_ENVIRONMENT_DIR}/terraform.tfvars" <<EOF

--- a/setup.sh
+++ b/setup.sh
@@ -59,6 +59,8 @@ fi
 
 echo "Setting up a new instance of Emblem. There may be a few prompts to guide the process."
 
+./scripts/bootstrap.sh
+
 #####################
 # Initial Ops Setup #
 #####################

--- a/terraform/modules/ops/services.tf
+++ b/terraform/modules/ops/services.tf
@@ -37,6 +37,13 @@ resource "time_sleep" "wait_for_cloud_build_service" {
   ]
 }
 
+resource "time_sleep" "wait_for_iam_service" {
+  create_duration = "20s"
+  depends_on = [
+    google_project_service.emblem_ops_services
+  ]
+}
+
 # Artifact Registry API enablement is eventually consistent
 # for brand-new GCP projects; we add a delay as a work-around.
 # For more information, see this GitHub issue:

--- a/terraform/modules/ops/testing.tf
+++ b/terraform/modules/ops/testing.tf
@@ -9,6 +9,9 @@ resource "google_service_account" "test_user" {
   account_id   = "test-user"
   display_name = "Test Account [User]"
   description  = "Mock user account for unit and integration tests."
+  depends_on = [
+    time_sleep.wait_for_iam_service
+  ]
 }
 
 resource "google_service_account" "test_approver" {
@@ -16,6 +19,9 @@ resource "google_service_account" "test_approver" {
   account_id   = "test-approver"
   display_name = "Test Account [Approver]"
   description  = "Mock approver account for unit and integration tests."
+  depends_on = [
+    time_sleep.wait_for_iam_service
+  ]
 }
 
 #######################


### PR DESCRIPTION
This PR is dependent on the following:
-  #730 for terraform build config 
- #734 for bootstrap script

This PR makes the following changes:
- executes `bootstrap.sh` from `setup.sh`
- executes ops, prod, and stage terraform via cloud build jobs
- updates `configure_delivery.sh` to use `repo_name` and `repo_owner` from project metadata defined in `bootstrap.sh`

This PR will also remove the following from `setup.sh` and `configure_delivery.sh` 
- Terraform bucket creation
- prompt for connecting repo to ops project

# To Test:
1. Set Emblem environment variables (`OPS_PROJECT`, `PROD_PROJECT`, `STAGE_PROJECT`)
2. Run `setup.sh`
3. Confirm successful deployment 
4. Make change in `web` directory in  forked repo to test deployment pipeline
5. Make change to `content_api` directory in forked repo to test deployment pipeline 

Fixes #712 
Also fixes #681 