### PR TITLE
fix(website/e2e-test): update package.json

### DIFF
--- a/website/e2e-test/package-lock.json
+++ b/website/e2e-test/package-lock.json
@@ -1,8 +1,52 @@
 {
   "name": "emblem-e2e-tests",
   "version": "0.0.1",
-  "lockfileVersion": 1,
+  "lockfileVersion": 2,
   "requires": true,
+  "packages": {
+    "": {
+      "name": "emblem-e2e-tests",
+      "version": "0.0.1",
+      "license": "Apache-2.0",
+      "devDependencies": {
+        "@playwright/test": "1.27.1"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.27.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.27.1.tgz",
+      "integrity": "sha512-mrL2q0an/7tVqniQQF6RBL2saskjljXzqNcCOVMUjRIgE6Y38nCNaP+Dc2FBW06bcpD3tqIws/HT9qiMHbNU0A==",
+      "dev": true,
+      "dependencies": {
+        "@types/node": "*",
+        "playwright-core": "1.27.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@playwright/test/node_modules/playwright-core": {
+      "version": "1.27.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.27.1.tgz",
+      "integrity": "sha512-9EmeXDncC2Pmp/z+teoVYlvmPWUC6ejSSYZUln7YaP89Z6lpAaiaAnqroUt/BoLo8tn7WYShcfaCh+xofZa44Q==",
+      "dev": true,
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "18.11.4",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.11.4.tgz",
+      "integrity": "sha512-BxcJpBu8D3kv/GZkx/gSMz6VnTJREBj/4lbzYOQueUOELkt8WrO6zAcSPmp9uRPEW/d+lUO8QK0W2xnS1hEU0A==",
+      "dev": true
+    }
+  },
   "dependencies": {
     "@playwright/test": {
       "version": "1.27.1",


### PR DESCRIPTION
This PR updates a generated file so that E2E tests will pass.

✅  _Website E2E tests are **passing** under this PR._

> (Ignore the `emblem-ops` failure; that check is deprecated.)