### PR TITLE
fix(ops): enable Cloud Run API in Terraform

### DIFF
--- a/terraform/environments/ops/main.tf
+++ b/terraform/environments/ops/main.tf
@@ -14,6 +14,7 @@ data "google_cloud_run_service" "content_api" {
   project  = var.prod_project_id
   name     = "content-api"
   location = var.region
+  count    = var.setup_e2e_tests ? 1 : 0
 }
 
 module "website_e2e_test" {
@@ -23,5 +24,5 @@ module "website_e2e_test" {
   region          = var.region
   repo_owner      = var.repo_owner
   repo_name       = var.repo_name
-  content_api_url = data.google_cloud_run_service.content_api.status[0].url
+  content_api_url = data.google_cloud_run_service.content_api[0].status[0].url
 }

--- a/terraform/modules/ops/services.tf
+++ b/terraform/modules/ops/services.tf
@@ -2,6 +2,7 @@ locals {
   services = var.enable_apis ? [
     "cloudbuild.googleapis.com",
     "pubsub.googleapis.com",
+    "run.googleapis.com",
     "secretmanager.googleapis.com",
     "cloudscheduler.googleapis.com",
     "cloudresourcemanager.googleapis.com",


### PR DESCRIPTION
Fixes #757