### PR TITLE
use built-in project var in e2e module

### DIFF
--- a/ops/web-e2e.cloudbuild.yaml
+++ b/ops/web-e2e.cloudbuild.yaml
@@ -17,7 +17,7 @@ steps:
   # Run E2E tests
   # These DO NOT use auth, so we can use a
   # "dummy value" for EMBLEM_SESSION_BUCKET
-  - name: '${_REGION}-docker.pkg.dev/${_PROJECT}/e2e-testing/runner:${_E2E_RUNNER_SHA}'
+  - name: '${_REGION}-docker.pkg.dev/${PROJECT_ID}/e2e-testing/runner:${_E2E_RUNNER_SHA}'
     entrypoint: /bin/bash
     args:
       - '-c'

--- a/terraform/modules/website-e2e-test/testing.tf
+++ b/terraform/modules/website-e2e-test/testing.tf
@@ -14,7 +14,6 @@ resource "google_cloudbuild_trigger" "testing_web_e2e_run_tests_trigger" {
     _DIR            = "website"
     _EMBLEM_URL     = "http://localhost:8080"
     _EMBLEM_API_URL = var.content_api_url
-    _PROJECT        = var.project_id
   }
   github {
     owner = var.repo_owner


### PR DESCRIPTION
This PR will:

- replace the _PROJECT substitution variable with the built-in PROJECT_ID variable in the e2e testing module cloud build config