### PR TITLE
testing: Run e2e test on test changes

### DIFF
--- a/terraform/modules/website-e2e-test/testing.tf
+++ b/terraform/modules/website-e2e-test/testing.tf
@@ -8,7 +8,8 @@ resource "google_cloudbuild_trigger" "testing_web_e2e_run_tests_trigger" {
   included_files = [
     "website/**",
     "ops/web-e2e.cloudbuild.yaml",
-    "terraform/modules/website-e2e-test/**"
+    "terraform/modules/website-e2e-test/**",
+    "testing/website-e2e/**"
   ]
   substitutions = {
     _DIR            = "website"

--- a/terraform/modules/website-e2e-test/testing.tf
+++ b/terraform/modules/website-e2e-test/testing.tf
@@ -9,7 +9,8 @@ resource "google_cloudbuild_trigger" "testing_web_e2e_run_tests_trigger" {
     "website/**",
     "ops/web-e2e.cloudbuild.yaml",
     "terraform/modules/website-e2e-test/**",
-    "testing/website-e2e/**"
+    "testing/website-e2e/**",
+    "ops/e2e-runner/**"
   ]
   substitutions = {
     _DIR            = "website"

--- a/terraform/modules/website-e2e-test/testing.tf
+++ b/terraform/modules/website-e2e-test/testing.tf
@@ -9,8 +9,7 @@ resource "google_cloudbuild_trigger" "testing_web_e2e_run_tests_trigger" {
     "website/**",
     "ops/web-e2e.cloudbuild.yaml",
     "terraform/modules/website-e2e-test/**",
-    "testing/website-e2e/**",
-    "ops/e2e-runner/**"
+    "testing/website-e2e/**"
   ]
   substitutions = {
     _DIR            = "website"


### PR DESCRIPTION
When changes are made to the testing/website-e2e directory, that should trigger the e2e test to be run. Currently PRs such as #794 are ignored, which means we cannot know if a particular test change breaks the test unintentionally.