### PR TITLE
testing: configure renovate to open WIP issue

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -5,6 +5,7 @@
   "ignorePaths": [
     "experimental/**"
   ],
+  "masterIssue": true,
   "rangeStrategy": "pin",
   "schedule": "before 10am every 3 weeks on Monday", 
   "packageRules": [


### PR DESCRIPTION
Enable masterIssue (at least temporarily) so we can see if there are pending updates for a dependency and (if works as advertised) force them through ahead of schedule.

https://www.mend.io/free-developer-tools/blog/introducing-renovates-master-issue/