### PR TITLE
testing: group openetelemetry dependency updates in single PR

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -13,6 +13,10 @@
         "client-libs/"
       ],
       "rangeStrategy": "replace"
-    }
+    },
+    {
+      "groupName": "OpenTelemetry",
+      "matchPackageNames": ["opentelemetry-*"]
+    },
   ]
 }


### PR DESCRIPTION
Similar to #802, instructs Renovate to group all otel libraries to update as a unit. Individually they typically fail testing.
Once merged, follow-up to see how to get renovate to revisit separate opentelemetry update PRs that will fail testing (e.g., #800)