### PR TITLE
testing: Use matchPackagePrefixes for opentelemetry-* grouping

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -21,7 +21,7 @@
     },
     {
       "groupName": "OpenTelemetry",
-      "matchPackageNames": ["opentelemetry-*"]
-    },
+      "matchPackagePrefixes": ["opentelemetry-"]
+    }
   ]
 }


### PR DESCRIPTION
The previous directive did not support wildcards.