### PR TITLE
Revert "chore(deps): update playwright 1.32.3"

### DIFF
--- a/ops/e2e-runner/Dockerfile
+++ b/ops/e2e-runner/Dockerfile
@@ -16,7 +16,7 @@
 # This Dockerfile is used to run the website for Playwright tests #
 ###################################################################
 
-FROM mcr.microsoft.com/playwright:v1.32.3-focal-amd64
+FROM mcr.microsoft.com/playwright:v1.32.1-focal-amd64
 RUN apt-get update && \
     apt-get install -y software-properties-common && \
     add-apt-repository ppa:deadsnakes/ppa -y && \

--- a/testing/website-e2e/package-lock.json
+++ b/testing/website-e2e/package-lock.json
@@ -9,17 +9,17 @@
       "version": "0.0.1",
       "license": "Apache-2.0",
       "devDependencies": {
-        "@playwright/test": "1.32.2"
+        "@playwright/test": "1.32.1"
       }
     },
     "node_modules/@playwright/test": {
-      "version": "1.32.2",
-      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.32.2.tgz",
-      "integrity": "sha512-nhaTSDpEdTTttdkDE8Z6K3icuG1DVRxrl98Qq0Lfc63SS9a2sjc9+x8ezysh7MzCKz6Y+nArml3/mmt+gqRmQQ==",
+      "version": "1.32.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.32.1.tgz",
+      "integrity": "sha512-FTwjCuhlm1qHUGf4hWjfr64UMJD/z0hXYbk+O387Ioe6WdyZQ+0TBDAc6P+pHjx2xCv1VYNgrKbYrNixFWy4Dg==",
       "dev": true,
       "dependencies": {
         "@types/node": "*",
-        "playwright-core": "1.32.2"
+        "playwright-core": "1.32.1"
       },
       "bin": {
         "playwright": "cli.js"
@@ -52,9 +52,9 @@
       }
     },
     "node_modules/playwright-core": {
-      "version": "1.32.2",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.32.2.tgz",
-      "integrity": "sha512-zD7aonO+07kOTthsrCR3YCVnDcqSHIJpdFUtZEMOb6//1Rc7/6mZDRdw+nlzcQiQltOOsiqI3rrSyn/SlyjnJQ==",
+      "version": "1.32.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.32.1.tgz",
+      "integrity": "sha512-KZYUQC10mXD2Am1rGlidaalNGYk3LU1vZqqNk0gT4XPty1jOqgup8KDP8l2CUlqoNKhXM5IfGjWgW37xvGllBA==",
       "dev": true,
       "bin": {
         "playwright": "cli.js"
@@ -66,14 +66,14 @@
   },
   "dependencies": {
     "@playwright/test": {
-      "version": "1.32.2",
-      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.32.2.tgz",
-      "integrity": "sha512-nhaTSDpEdTTttdkDE8Z6K3icuG1DVRxrl98Qq0Lfc63SS9a2sjc9+x8ezysh7MzCKz6Y+nArml3/mmt+gqRmQQ==",
+      "version": "1.32.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.32.1.tgz",
+      "integrity": "sha512-FTwjCuhlm1qHUGf4hWjfr64UMJD/z0hXYbk+O387Ioe6WdyZQ+0TBDAc6P+pHjx2xCv1VYNgrKbYrNixFWy4Dg==",
       "dev": true,
       "requires": {
         "@types/node": "*",
         "fsevents": "2.3.2",
-        "playwright-core": "1.32.2"
+        "playwright-core": "1.32.1"
       }
     },
     "@types/node": {
@@ -90,9 +90,9 @@
       "optional": true
     },
     "playwright-core": {
-      "version": "1.32.2",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.32.2.tgz",
-      "integrity": "sha512-zD7aonO+07kOTthsrCR3YCVnDcqSHIJpdFUtZEMOb6//1Rc7/6mZDRdw+nlzcQiQltOOsiqI3rrSyn/SlyjnJQ==",
+      "version": "1.32.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.32.1.tgz",
+      "integrity": "sha512-KZYUQC10mXD2Am1rGlidaalNGYk3LU1vZqqNk0gT4XPty1jOqgup8KDP8l2CUlqoNKhXM5IfGjWgW37xvGllBA==",
       "dev": true
     }
   }

--- a/testing/website-e2e/package.json
+++ b/testing/website-e2e/package.json
@@ -17,6 +17,6 @@
   },
   "homepage": "https://github.com/googlecloudplatform/emblem#readme",
   "devDependencies": {
-    "@playwright/test": "1.32.2"
+    "@playwright/test": "1.32.1"
   }
 }


### PR DESCRIPTION
Reverts GoogleCloudPlatform/emblem#819

This change has led to test failures. Either the dependency updates being grouped are on a staggered schedule, or something is preventing Playwright Test from installing to the correct version. I'm not sure what's going on with that. Let's revert and plan a playwright update policy, a blend of playwright brittleness with (maybe) something else we are doing is making any change to playwright high risk.

```
    browserType.launch: Executable doesn't exist at /ms-playwright/chromium-1048/chrome-linux/chrome
    ╔══════════════════════════════════════════════════════════════════════╗
    ║ Looks like Playwright Test or Playwright was just updated to 1.31.2. ║
    ║ Please update docker image as well.                                  ║
    ║ -  current: mcr.microsoft.com/playwright:v1.32.3-focal               ║
    ║ - required: mcr.microsoft.com/playwright:v1.31.2-focal               ║
    ║                                                                      ║
    ║ <3 Playwright Team                                                   ║
    ╚══════════════════════════════════════════════════════════════════════╝
```