### PR TITLE
deps: improve grouping and reviewer guidance

### DIFF
--- a/docs/decisions/2023-03-31-playwright-dependencies.md
+++ b/docs/decisions/2023-03-31-playwright-dependencies.md
@@ -76,3 +76,4 @@ not have as part of the available time for maintenance improvements.
 ## Links
 
 * [#822](https://github.com/GoogleCloudPlatform/emblem/pull/822)
+* [#847](https://github.com/GoogleCloudPlatform/emblem/issues/847)

--- a/renovate.json5
+++ b/renovate.json5
@@ -72,43 +72,20 @@
     },
     {
       // Bundle non-major dependencies for Website Python code.
-      // Exclude frameworks and libraries where our usage
-      // lacks test coverage.
+      // Exclude frameworks and libraries where our usage lacks test coverage.
       "groupName": "Website (Python)",
       "matchPaths": ["website/**", "client-libs/**", "client-app/**"],
       "matchLanguages": ["python"],
       "matchUpdateTypes": ["minor", "patch"],
+      // Excluding flask from Website and Content API is by design:
+      // framework changes are significant and we group them across components.
       "excludePackageNames": ["flask"],
     },
     {
-      // Bundle non-major dependencies for Website JS code.
-      // Exclude frameworks and libraries where our usage
-      // lacks test coverage.
-      "groupName": "Website (JS Runtime)",
-      "matchPaths": ["website/**", "client-libs/**", "client-app/**"],
-      "matchLanguages": ["javascript"],
-      "matchUpdateTypes": ["minor", "patch"],
-      // Scope the code to what we use in production operation
-      "matchDepTypes": ["dependencies"],
-      "excludePackageNames": ["lit"],
-    },
-    {
-      // Bundle non-major dependencies for Website JS code.
-      "groupName": "Website (JS Build)",
-      "matchPaths": ["website/**", "client-libs/**", "client-app/**"],
-      "matchLanguages": ["javascript"],
-      "matchUpdateTypes": ["minor", "patch"],
-      // Scope the code to what we use during development
-      // and build processes.
-      "matchDepTypes": ["devDependencies"],
-    },
-    {
       // Bundle non-major dependencies for Content API Python code.
-      // Exclude frameworks and libraries where our usage
-      // lacks test coverage.
+      // Exclude frameworks and libraries where our usage lacks test coverage.
       //
-      // Currently the only API package under test
-      // is google-cloud-firestore.
+      // Currently the only API package under test is google-cloud-firestore.
       "groupName": "Content API",
       "matchPaths": ["content-api/**"],
       "matchLanguages": ["python"],
@@ -116,14 +93,47 @@
       "matchPackageNames": ["google-cloud-firestore"],
     },
     {
-      // Playwright dependencies require tight alignment
-      "groupName": "Playwright",
-      "matchPackageNames": ["playwright", "@playwright/test", "mcr.microsoft.com/playwright"],
+      // Bundle non-major dependencies for Website JS code.
+      // Exclude frameworks and libraries where our usage lacks test coverage.
+      "groupName": "Website (JS Runtime)",
+      "matchPaths": ["website/**", "client-libs/**", "client-app/**"],
+      "matchLanguages": ["js", "node"],
+      "matchUpdateTypes": ["minor", "patch"],
+      // Scope the code to what we use in production operation.
+      "matchDepTypes": ["dependencies"],
+      "excludePackageNames": ["lit"],
     },
     {
-      // OpenTelemetry dependencies require tight alignment
+      // Bundle dependencies for Website JS build code.
+      "groupName": "Website (JS Build)",
+      "matchPaths": ["website/**", "client-libs/**", "client-app/**"],
+      "matchLanguages": ["js", "node"],
+      // Scope the code to what we use during development and build processes.
+      "matchDepTypes": ["devDependencies"],
+    },
+    {
+      // Playwright dependencies require tight alignment.
+      "groupName": "Playwright",
+      "matchPackageNames": ["playwright", "@playwright/test", "mcr.microsoft.com/playwright"],
+      // Run daily as a low-impact check for group updates.
+      "schedule": "before 6am every day",
+      "prBodyNotes": [
+        ":warning: Playwright dependencies may roll out on a staggered schedule.",
+        "If tests are not passing due to version conflict, wait for other packages",
+        "and re-run renovate on this PR to retry the update.",
+      ],
+    },
+    {
+      // OpenTelemetry dependencies require tight alignment.
       "groupName": "OpenTelemetry",
       "matchPackagePrefixes": ["opentelemetry-"],
+      // Run daily as a low-impact check for group updates.
+      "schedule": "before 6am every day",
+      "prBodyNotes": [
+        ":warning: OpenTelemetry dependencies may roll out on a staggered schedule.",
+        "If tests are not passing due to version conflict, wait for other packages",
+        "and re-run renovate on this PR to retry the update.",
+      ],
     },
   ],
 }


### PR DESCRIPTION
Fixes #847

## Description

Many changes show up in this PR.

* Group majors along with Node.js devDependencies, which ends up grouping major update and non-major updates in two different PRs.
* Have renovate check for OpenTelemetry and Playwright updates every day before EST business hours. This is to address staggered package release.
* Fix grouping by JavaScript: Renovate pays attention to `node` and `js`, not `javascript`. 🤦 
* Formatting: Converge closer on line length 80 and make use of the space where it was oddly shortened.
* Add #847 as a follow-up reference to the decision record.
* Add a reviewer note for OpenTelemetry and Playwright PRs to provide additional guidance

## How I tested

```
npm install -g renovate
LOG_LEVEL=debug renovate --dry-run --token $(gh auth token) grayside/emblem > renovate.out
```

In VSCode, I used the search tab and looked through the file for `branchName`, each dependency update has this value and it's the representation in the debug output for how a given dependency update will be grouped.

<details>
<summary>Example `branchName` Search: Click to Expand</summary>

![Screenshot 2023-04-18 at 3 02 08 PM](https://user-images.githubusercontent.com/283489/232914992-66b0c008-5f94-4c97-aed0-2400a9983bac.png)
</details>
