### PR TITLE
fix: updating from google.auth to google-auth

### DIFF
--- a/content-api/requirements.txt
+++ b/content-api/requirements.txt
@@ -2,7 +2,7 @@ flask==2.2.2
 google-cloud-firestore==2.10.0
 Flask-Cors==3.0.10
 gunicorn==20.1.0
-google.auth==2.16.0
+google-auth==2.16.0
 requests==2.28.2
 # opentelemetry libraries
 opentelemetry-api==1.17.0

--- a/website/requirements.txt
+++ b/website/requirements.txt
@@ -1,6 +1,7 @@
 Flask==2.2.3
 firebase-admin==6.1.0
 gunicorn==20.1.0
+google-auth==2.16.0
 requests==2.28.2
 pytz==2023.3
 opentelemetry-distro==0.33b0


### PR DESCRIPTION
**Issue:** To resolve `api-unit-test` failures in recent PRs siting `ModuleNotFoundError: No module named 'google' from google.auth.transport import requests as reqs`. 

Ex: https://github.com/GoogleCloudPlatform/emblem/pull/913