### PR TITLE
fix: small fix for web-e2e build trigger

### DIFF
--- a/ops/web-e2e.cloudbuild.yaml
+++ b/ops/web-e2e.cloudbuild.yaml
@@ -74,5 +74,6 @@ substitutions:
   _E2E_RUNNER_SHA: latest
   _EMBLEM_SESSION_BUCKET: nonexistent-bucket # no-op placeholder value
   _EMBLEM_URL: "http://localhost:8080"
+  _EMBLEM_API_URL: point-to-prod-url # no-op placeholder value (added via terraform/modules/website-e2e-test/testing.tf)
   _FLASK_PORT: "8080"
   _REGION: us-central1

--- a/scripts/configure_delivery.sh
+++ b/scripts/configure_delivery.sh
@@ -94,5 +94,5 @@ fi
 # Build container for running E2E tests
 E2E_RUNNER_TAG="latest"
 E2E_BUILD_ID=$(gcloud builds submit "ops/e2e-runner" --async \
-    --config=ops/e2e-runner-build.cloudbuild.yaml \
-    --project="$OPS_PROJECT" --substitutions=_REGION="$REGION",_IMAGE_TAG="$E2E_RUNNER_TAG" --format='value(ID)')
+    --config=ops/web-e2e.cloudbuild.yaml \
+    --project="$OPS_PROJECT" --substitutions=_REGION="$REGION",_E2E_RUNNER_SHA="$E2E_RUNNER_TAG," --format='value(ID)')

--- a/scripts/configure_delivery.sh
+++ b/scripts/configure_delivery.sh
@@ -95,4 +95,4 @@ fi
 E2E_RUNNER_TAG="latest"
 E2E_BUILD_ID=$(gcloud builds submit "ops/e2e-runner" --async \
     --config=ops/web-e2e.cloudbuild.yaml \
-    --project="$OPS_PROJECT" --substitutions=_REGION="$REGION",_E2E_RUNNER_SHA="$E2E_RUNNER_TAG," --format='value(ID)')
+    --project="$OPS_PROJECT" --substitutions=_REGION="$REGION",_E2E_RUNNER_SHA="$E2E_RUNNER_TAG" --format='value(ID)')


### PR DESCRIPTION
**Issue:** Updating references from old `e2e-runner-build` to new `web-e2e` and substitution expectations that go with it.

* Updating old `e2e-runner-build` file ref
![Screenshot 2023-06-20 at 4 39 36 PM](https://github.com/GoogleCloudPlatform/emblem/assets/1331216/b5a69e57-630b-46d8-9795-599548c1b8c0)

* Updating substitutions
![Screenshot 2023-06-20 at 5 12 28 PM](https://github.com/GoogleCloudPlatform/emblem/assets/1331216/6c00378c-7b50-4250-8d2a-4c9801492868)
