### PR TITLE
fix(issue-848): resolve silent errors in api unit tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -151,6 +151,9 @@ node_modules/
 # Mac stuff
 .DS_Store
 
+# VSCode
+.vscode
+
 # Vim temp files
 *.swo
 *.swp

--- a/content-api/data/seed_database.py
+++ b/content-api/data/seed_database.py
@@ -33,7 +33,6 @@ def seed_approver(email):
 
 
 def seed_database(content):
-
     client = firestore.Client()
     print("Seeding data into Google Cloud Project '{}'.".format(client.project))
     print("This may take a few minutes...")
@@ -49,7 +48,6 @@ def seed_database(content):
 
 
 def unseed_database():
-
     client = firestore.Client()
     print("Deleting seed data from Google Cloud Project '{}'.".format(client.project))
     print("This may take a few minutes...")

--- a/content-api/requirements.txt
+++ b/content-api/requirements.txt
@@ -4,6 +4,7 @@ Flask-Cors==3.0.10
 gunicorn==20.1.0
 google-auth==2.20.0
 requests==2.31.0
+pytest-is-running==1.4.0
 # opentelemetry libraries
 opentelemetry-api==1.18.0
 opentelemetry-sdk==1.18.0


### PR DESCRIPTION
Fix Issue: #848  

**Part 1:** Wrap python unit tests to fail when exception is thrown
**Part 2:** Prevent otel running during unit test runs

**To verify:** 
Open `api-unit-tests` check below and `Unit tests` step (last step) should no longer be displaying `Error while writing to Cloud Trace` logs related to otel.

Before fix:
![Screenshot 2023-06-29 at 7 05 12 PM](https://github.com/GoogleCloudPlatform/emblem/assets/1331216/ee26a718-4ef0-46f9-86d9-a44268f013da)

After fix:
![Screenshot 2023-06-29 at 7 09 22 PM](https://github.com/GoogleCloudPlatform/emblem/assets/1331216/32b8af41-4c08-4493-ab7d-2ec9e2a38664)
