### PR TITLE
fix: wrong requirements txt ref in unit test cloudbuild yaml

### DIFF
--- a/content-api/requirements.txt
+++ b/content-api/requirements.txt
@@ -2,7 +2,7 @@ flask==2.3.2
 google-cloud-firestore==2.10.0
 Flask-Cors==4.0.0
 gunicorn==20.1.0
-google-auth==2.21.0
+google-auth==2.3.3
 requests==2.31.0
 pytest-is-running==1.5.0
 # opentelemetry libraries

--- a/ops/unit-tests.cloudbuild.yaml
+++ b/ops/unit-tests.cloudbuild.yaml
@@ -17,7 +17,7 @@ steps:
   - id: "Install Dependencies"
     name: python:3.11-slim
     dir: ${_DIR}
-    script: pip install -r requirements-test.txt --user
+    script: pip install -r requirements.txt --user
 
   # Install test requirements
   - id: "Install Pytest"


### PR DESCRIPTION
Fixes: #953 

To understand issue:
* Latest related error log https://pantheon.corp.google.com/cloud-build/builds;region=global/5e1239d2-a7e5-4501-9c4e-449cfb4ad86a?project=emblem-ci-ops

Actions taken:
* Updates `google-auth`
* Restores back to `requirements.txt` rather than referencing `requirements-test.txt` twice in unit-test.cloudbuild.yaml (main fix - ref: https://github.com/GoogleCloudPlatform/emblem/commit/003d6d501c6f568c56ed77bd3eaff6b4c5ba47a4)