### PR TITLE
fix: otel mismatching deps

### DIFF
--- a/content-api/requirements.txt
+++ b/content-api/requirements.txt
@@ -6,12 +6,12 @@ google-auth==2.23.4
 requests==2.31.0
 pytest-is-running==1.5.0
 # opentelemetry libraries
-opentelemetry-api==1.20.0
-opentelemetry-sdk==1.20.0
-opentelemetry-distro==0.41b0
+opentelemetry-api==1.21.0
+opentelemetry-sdk==1.21.0
+opentelemetry-distro==0.42b0
 opentelemetry-exporter-gcp-trace==1.6.0
-opentelemetry-instrumentation==0.41b0
-opentelemetry-instrumentation-flask==0.41b0
+opentelemetry-instrumentation==0.42b0
+opentelemetry-instrumentation-flask==0.42b0
 opentelemetry-resourcedetector-gcp==1.5.0a0
-opentelemetry-semantic-conventions==0.41b0
+opentelemetry-semantic-conventions==0.42b0
 opentelemetry-propagator-gcp==1.6.0


### PR DESCRIPTION
Resolving in `opentelemetry-semantic-conventions==0.41b0` mismatch in
PR: https://github.com/GoogleCloudPlatform/emblem/pull/995